### PR TITLE
Fixed dcc-4.9x build error on OSX

### DIFF
--- a/sdk/toolchain/Makefile
+++ b/sdk/toolchain/Makefile
@@ -28,9 +28,9 @@ arm_prefix := /opt/toolchains/dc/$(arm_target)
 kos_root=/usr/local/dc/kos
 # kos_base: equivalent of KOS_BASE (contains include/ and kernel/)
 kos_base=/usr/local/dc/kos/kos
-binutils_ver=2.23.2
+binutils_ver=2.25
 gcc_ver=4.9.1
-newlib_ver=2.0.0
+newlib_ver=2.2.0
 gdb_ver=7.6
 insight_ver=6.7.1
 
@@ -62,7 +62,7 @@ SHELL = /bin/bash
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
   ifneq ($(shell $(CXX) --version | grep clang),)
-    CXX := "$(CXX) -stdlib=libstdc++"
+    CXX := "$(CXX) -stdlib=libstdc++ -fbracket-depth=1024"
   endif
 endif
 
@@ -118,7 +118,7 @@ build: build-sh4 build-arm
 build-sh4: build-sh4-binutils build-sh4-gcc
 build-arm: build-arm-binutils build-arm-gcc
 build-sh4-gcc: build-sh4-gcc-pass1 build-sh4-newlib build-sh4-gcc-pass2
-build-arm-gcc: build-arm-gcc-pass1 #build-arm-newlib
+build-arm-gcc: build-arm-gcc-pass1
 	$(clean_arm_hack)
 build-sh4-newlib: build-sh4-newlib-only fixup-sh4-newlib
 build-arm-newlib: build-arm-newlib-only fixup-arm-newlib
@@ -139,7 +139,7 @@ $(build_arm_targets): extra_configure_args = --with-arch=armv4
 # can't be run multiple times.  So we create multiple targets.
 build_binutils     = build-sh4-binutils  build-arm-binutils
 build_gcc_pass1    = build-sh4-gcc-pass1 build-arm-gcc-pass1
-build_newlib       = build-sh4-newlib-only #build-arm-newlib-only
+build_newlib       = build-sh4-newlib-only
 build_gcc_pass2    = build-sh4-gcc-pass2
 
 # Here we use the essentially same code for multiple targets,

--- a/sdk/toolchain/download.sh
+++ b/sdk/toolchain/download.sh
@@ -2,8 +2,8 @@
 
 # These version numbers are all that should ever have to be changed.
 export GCC_VER=4.9.1
-export BINUTILS_VER=2.23.2
-export NEWLIB_VER=2.0.0
+export BINUTILS_VER=2.25
+export NEWLIB_VER=2.2.0
 export GMP_VER=4.3.2
 export MPFR_VER=2.4.2
 export MPC_VER=0.8.1

--- a/sdk/toolchain/patches/newlib-2.2.0-kos.diff
+++ b/sdk/toolchain/patches/newlib-2.2.0-kos.diff
@@ -1,6 +1,6 @@
-diff -ruN newlib-2.0.0/newlib/configure.host newlib-2.0.0-kos/newlib/configure.host
---- newlib-2.0.0/newlib/configure.host	2012-12-04 16:43:20.000000000 -0500
-+++ newlib-2.0.0-kos/newlib/configure.host	2013-05-18 00:16:34.000000000 -0400
+diff -ruN newlib-2.2.0/newlib/configure.host newlib-2.2.0-kos/newlib/configure.host
+--- newlib-2.2.0/newlib/configure.host	2012-12-04 16:43:20.000000000 -0500
++++ newlib-2.2.0-kos/newlib/configure.host	2013-05-18 00:16:34.000000000 -0400
 @@ -245,6 +245,7 @@
  	;;
    sh | sh64)
@@ -9,9 +9,9 @@ diff -ruN newlib-2.0.0/newlib/configure.host newlib-2.0.0-kos/newlib/configure.h
  	;;
    sparc*)
  	machine_dir=sparc
-diff -ruN newlib-2.0.0/newlib/libc/include/assert.h newlib-2.0.0-kos/newlib/libc/include/assert.h
---- newlib-2.0.0/newlib/libc/include/assert.h	2012-10-16 15:00:30.000000000 -0400
-+++ newlib-2.0.0-kos/newlib/libc/include/assert.h	2013-05-18 00:17:28.000000000 -0400
+diff -ruN newlib-2.2.0/newlib/libc/include/assert.h newlib-2.2.0-kos/newlib/libc/include/assert.h
+--- newlib-2.2.0/newlib/libc/include/assert.h	2012-10-16 15:00:30.000000000 -0400
++++ newlib-2.2.0-kos/newlib/libc/include/assert.h	2013-05-18 00:17:28.000000000 -0400
 @@ -13,8 +13,8 @@
  #ifdef NDEBUG           /* required by ANSI standard */
  # define assert(__e) ((void)0)
@@ -36,9 +36,9 @@ diff -ruN newlib-2.0.0/newlib/libc/include/assert.h newlib-2.0.0-kos/newlib/libc
  
  #if __STDC_VERSION__ >= 201112L && !defined __cplusplus
  # define static_assert _Static_assert
-diff -ruN newlib-2.0.0/newlib/libc/include/machine/_default_types.h newlib-2.0.0-kos/newlib/libc/include/machine/_default_types.h
---- newlib-2.0.0/newlib/libc/include/machine/_default_types.h	2012-10-16 14:45:23.000000000 -0400
-+++ newlib-2.0.0-kos/newlib/libc/include/machine/_default_types.h	2013-05-18 01:00:45.000000000 -0400
+diff -ruN newlib-2.2.0/newlib/libc/include/machine/_default_types.h newlib-2.2.0-kos/newlib/libc/include/machine/_default_types.h
+--- newlib-2.2.0/newlib/libc/include/machine/_default_types.h	2012-10-16 14:45:23.000000000 -0400
++++ newlib-2.2.0-kos/newlib/libc/include/machine/_default_types.h	2013-05-18 01:00:45.000000000 -0400
 @@ -9,6 +9,8 @@
  extern "C" {
  #endif
@@ -48,9 +48,9 @@ diff -ruN newlib-2.0.0/newlib/libc/include/machine/_default_types.h newlib-2.0.0
  /*
   * Guess on types by examining *_MIN / *_MAX defines.
   */
-diff -ruN newlib-2.0.0/newlib/libc/include/sys/types.h newlib-2.0.0-kos/newlib/libc/include/sys/types.h
---- newlib-2.0.0/newlib/libc/include/sys/types.h	2012-07-06 06:41:21.000000000 -0400
-+++ newlib-2.0.0-kos/newlib/libc/include/sys/types.h	2013-05-18 00:23:09.000000000 -0400
+diff -ruN newlib-2.2.0/newlib/libc/include/sys/types.h newlib-2.2.0-kos/newlib/libc/include/sys/types.h
+--- newlib-2.2.0/newlib/libc/include/sys/types.h	2012-07-06 06:41:21.000000000 -0400
++++ newlib-2.2.0-kos/newlib/libc/include/sys/types.h	2013-05-18 00:23:09.000000000 -0400
 @@ -286,7 +286,7 @@
  
  #if defined(__XMK__)
@@ -116,9 +116,9 @@ diff -ruN newlib-2.0.0/newlib/libc/include/sys/types.h newlib-2.0.0-kos/newlib/l
  #else
  #if defined (__CYGWIN__)
  #include <cygwin/types.h>
-diff -ruN newlib-2.0.0/newlib/libc/stdlib/assert.c newlib-2.0.0-kos/newlib/libc/stdlib/assert.c
---- newlib-2.0.0/newlib/libc/stdlib/assert.c	2009-10-08 12:44:10.000000000 -0400
-+++ newlib-2.0.0-kos/newlib/libc/stdlib/assert.c	2013-05-18 00:23:54.000000000 -0400
+diff -ruN newlib-2.2.0/newlib/libc/stdlib/assert.c newlib-2.2.0-kos/newlib/libc/stdlib/assert.c
+--- newlib-2.2.0/newlib/libc/stdlib/assert.c	2009-10-08 12:44:10.000000000 -0400
++++ newlib-2.2.0-kos/newlib/libc/stdlib/assert.c	2013-05-18 00:23:54.000000000 -0400
 @@ -47,6 +47,8 @@
  #include <stdlib.h>
  #include <stdio.h>
@@ -133,9 +133,9 @@ diff -ruN newlib-2.0.0/newlib/libc/stdlib/assert.c newlib-2.0.0-kos/newlib/libc/
    /* NOTREACHED */
  }
 +#endif
-diff -ruN newlib-2.0.0/newlib/libc/sys/sh/ftruncate.c newlib-2.0.0-kos/newlib/libc/sys/sh/ftruncate.c
---- newlib-2.0.0/newlib/libc/sys/sh/ftruncate.c	2003-07-10 11:31:30.000000000 -0400
-+++ newlib-2.0.0-kos/newlib/libc/sys/sh/ftruncate.c	2013-05-18 00:27:35.000000000 -0400
+diff -ruN newlib-2.2.0/newlib/libc/sys/sh/ftruncate.c newlib-2.2.0-kos/newlib/libc/sys/sh/ftruncate.c
+--- newlib-2.2.0/newlib/libc/sys/sh/ftruncate.c	2003-07-10 11:31:30.000000000 -0400
++++ newlib-2.2.0-kos/newlib/libc/sys/sh/ftruncate.c	2013-05-18 00:27:35.000000000 -0400
 @@ -1,9 +1 @@
 -#include <_ansi.h>
 -#include <sys/types.h>
@@ -147,9 +147,9 @@ diff -ruN newlib-2.0.0/newlib/libc/sys/sh/ftruncate.c newlib-2.0.0-kos/newlib/li
 -  return __trap34 (SYS_ftruncate, file, length, 0);
 -}
 +/* Nothing here. */
-diff -ruN newlib-2.0.0/newlib/libc/sys/sh/sys/lock.h newlib-2.0.0-kos/newlib/libc/sys/sh/sys/lock.h
---- newlib-2.0.0/newlib/libc/sys/sh/sys/lock.h	1969-12-31 19:00:00.000000000 -0500
-+++ newlib-2.0.0-kos/newlib/libc/sys/sh/sys/lock.h	2013-05-18 00:26:13.000000000 -0400
+diff -ruN newlib-2.2.0/newlib/libc/sys/sh/sys/lock.h newlib-2.2.0-kos/newlib/libc/sys/sh/sys/lock.h
+--- newlib-2.2.0/newlib/libc/sys/sh/sys/lock.h	1969-12-31 19:00:00.000000000 -0500
++++ newlib-2.2.0-kos/newlib/libc/sys/sh/sys/lock.h	2013-05-18 00:26:13.000000000 -0400
 @@ -0,0 +1,51 @@
 +/* KallistiOS ##version##
 +
@@ -202,9 +202,9 @@ diff -ruN newlib-2.0.0/newlib/libc/sys/sh/sys/lock.h newlib-2.0.0-kos/newlib/lib
 +
 +
 +#endif // __NEWLIB_LOCK_COMMON_H
-diff -ruN newlib-2.0.0/newlib/libc/sys/sh/syscalls.c newlib-2.0.0-kos/newlib/libc/sys/sh/syscalls.c
---- newlib-2.0.0/newlib/libc/sys/sh/syscalls.c	2008-01-21 19:24:45.000000000 -0500
-+++ newlib-2.0.0-kos/newlib/libc/sys/sh/syscalls.c	2013-05-18 00:26:46.000000000 -0400
+diff -ruN newlib-2.2.0/newlib/libc/sys/sh/syscalls.c newlib-2.2.0-kos/newlib/libc/sys/sh/syscalls.c
+--- newlib-2.2.0/newlib/libc/sys/sh/syscalls.c	2008-01-21 19:24:45.000000000 -0500
++++ newlib-2.2.0-kos/newlib/libc/sys/sh/syscalls.c	2013-05-18 00:26:46.000000000 -0400
 @@ -1,228 +1,2 @@
 -#include <_ansi.h>
 -#include <sys/types.h>
@@ -436,9 +436,9 @@ diff -ruN newlib-2.0.0/newlib/libc/sys/sh/syscalls.c newlib-2.0.0-kos/newlib/lib
 -}
 +// This is put in here to cause link errors if a proper newlib isn't present.
 +int __newlib_kos_patch = 1;
-diff -ruN newlib-2.0.0/newlib/libc/sys/sh/trap.S newlib-2.0.0-kos/newlib/libc/sys/sh/trap.S
---- newlib-2.0.0/newlib/libc/sys/sh/trap.S	2002-02-08 02:11:13.000000000 -0500
-+++ newlib-2.0.0-kos/newlib/libc/sys/sh/trap.S	2013-05-18 00:27:04.000000000 -0400
+diff -ruN newlib-2.2.0/newlib/libc/sys/sh/trap.S newlib-2.2.0-kos/newlib/libc/sys/sh/trap.S
+--- newlib-2.2.0/newlib/libc/sys/sh/trap.S	2002-02-08 02:11:13.000000000 -0500
++++ newlib-2.2.0-kos/newlib/libc/sys/sh/trap.S	2013-05-18 00:27:04.000000000 -0400
 @@ -1,43 +0,0 @@
 -#if __SH5__
 -	.mode	SHmedia
@@ -483,9 +483,9 @@ diff -ruN newlib-2.0.0/newlib/libc/sys/sh/trap.S newlib-2.0.0-kos/newlib/libc/sy
 -perrno:
 -	.long	_errno
 -#endif /* ! __SH5__ */
-diff -ruN newlib-2.0.0/newlib/libc/sys/sh/truncate.c newlib-2.0.0-kos/newlib/libc/sys/sh/truncate.c
---- newlib-2.0.0/newlib/libc/sys/sh/truncate.c	2003-07-10 11:31:30.000000000 -0400
-+++ newlib-2.0.0-kos/newlib/libc/sys/sh/truncate.c	2013-05-18 00:27:23.000000000 -0400
+diff -ruN newlib-2.2.0/newlib/libc/sys/sh/truncate.c newlib-2.2.0-kos/newlib/libc/sys/sh/truncate.c
+--- newlib-2.2.0/newlib/libc/sys/sh/truncate.c	2003-07-10 11:31:30.000000000 -0400
++++ newlib-2.2.0-kos/newlib/libc/sys/sh/truncate.c	2013-05-18 00:27:23.000000000 -0400
 @@ -1,9 +1 @@
 -#include <_ansi.h>
 -#include <sys/types.h>

--- a/sdk/toolchain/unpack.sh
+++ b/sdk/toolchain/unpack.sh
@@ -2,8 +2,8 @@
 
 # These version numbers are all that should ever have to be changed.
 export GCC_VER=4.9.1
-export BINUTILS_VER=2.23.2
-export NEWLIB_VER=2.0.0
+export BINUTILS_VER=2.25
+export NEWLIB_VER=2.2.0
 export GMP_VER=4.3.2
 export MPFR_VER=2.4.2
 export MPC_VER=0.8.1


### PR DESCRIPTION
Updated binutils to 2.25 ver
Updated newlib to 2.2.0 ver and added patch to it