### PR TITLE
bootloader: fix crash when using sata hdd without sdcard

### DIFF
--- a/firmware/bootloader/src/menu.c
+++ b/firmware/bootloader/src/menu.c
@@ -231,7 +231,7 @@ static int search_root() {
 	
 	while ((ent = fs_readdir(hnd)) != NULL) {
 		
-		if(ent->name[0] == 0 || !strncasecmp(ent->name, "pty", 3) ||
+		if(ent->name[0] == 0 || !strncasecmp(ent->name, "pty", 3) || !strncasecmp(ent->name, "ram", 3) ||
 			!strncasecmp(ent->name, "sock", 4) || !strncasecmp(ent->name, "vmu", 3)) {
 			continue;
 		}


### PR DESCRIPTION
This PR remove "/ram" from root search. 

This fix:
- Bios boot when using a sata hdd without an sdcard inserted (bootloader crash on "fs_open" on "/ram)
- Bios boot when "DS" folder is present on hdd AND sdcard (bootloader crash on "fs_open" on "/ram)