### PR TITLE
Fix building with recent HOST compilers (gcc 8 or higher)

### DIFF
--- a/sdk/toolchain/fedora_build.sh
+++ b/sdk/toolchain/fedora_build.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# number of cpu cores
+cores="$(grep -c ^processor /proc/cpuinfo )"
+
+# exports
+export SH_PREFIX=/opt/toolchains/dc/sh-elf
+export ARM_PREFIX=/opt/toolchains/dc/arm-eabi
+export KOS_ROOT=/usr/local/dc/kos
+export KOS_BASE=$KOS_ROOT/kos
+export KOS_PORTS=$KOS_ROOT/kos-ports
+
+# install deps and setup directories
+sudo dnf install subversion gcc gcc-c++ make automake autoconf  m4 \
+	bison elfutils-libelf-devel flex libtool texinfo gawk \
+	latex2html git sed wget libpng-devel lyx libjpeg-turbo-devel \
+	mpfr-devel gmp-devel isl-devel intltool zlib-devel
+
+sudo mkdir -p $KOS_ROOT
+sudo mkdir -p $SH_PREFIX/sh-elf/include
+sudo mkdir -p $ARM_PREFIX/share
+sudo chown -R $USER:$USER $ARM_PREFIX
+sudo chown -R $USER:$USER $SH_PREFIX
+sudo chown -R $USER:$USER $KOS_ROOT
+
+# clone kos
+git clone git://git.code.sf.net/p/cadcdev/kallistios kos
+git clone --recursive git://git.code.sf.net/p/cadcdev/kos-ports kos-ports
+cp -r kos $KOS_ROOT
+rm -rf kos
+cp -r kos-ports $KOS_ROOT
+rm -rf kos-ports
+
+# prepare
+./download.sh
+./unpack.sh
+cd gcc-5.2.0
+./contrib/download_prerequisites
+cd .. && make patch
+
+# build
+make -j${cores} build-sh4-binutils
+make -j${cores} build-sh4-gcc-pass1
+make -j${cores} build-sh4-newlib-only
+make -j${coreS} fixup-sh4-newlib
+make -j${cores} build-sh4-gcc-pass2
+make -j${coreS} build-arm-binutils
+make -j${cores} build-arm-gcc
+
+# env script
+cp $KOS_BASE/doc/environ.sh.sample $KOS_BASE/environ.sh
+sed -i 's/\/opt\/toolchains\/dc\/kos/\/usr\/local\/dc\/kos\/kos/g' $KOS_BASE/environ.sh
+source $KOS_BASE/environ.sh
+
+# build kos and kos-ports
+pushd `pwd`
+cd $KOS_BASE
+make -j${cores}
+cd $KOS_PORTS
+./utils/build-all.sh
+popd

--- a/sdk/toolchain/fedora_build.sh
+++ b/sdk/toolchain/fedora_build.sh
@@ -11,10 +11,10 @@ export KOS_BASE=$KOS_ROOT/kos
 export KOS_PORTS=$KOS_ROOT/kos-ports
 
 # install deps and setup directories
-sudo dnf install subversion gcc gcc-c++ make automake autoconf  m4 \
+sudo dnf install subversion gcc gcc-c++ make automake autoconf m4 \
 	bison elfutils-libelf-devel flex libtool texinfo gawk \
 	latex2html git sed wget libpng-devel lyx libjpeg-turbo-devel \
-	mpfr-devel gmp-devel isl-devel intltool zlib-devel
+	mpfr-devel gmp-devel isl-devel intltool zlib-devel diffutils patch
 
 sudo mkdir -p $KOS_ROOT
 sudo mkdir -p $SH_PREFIX/sh-elf/include

--- a/sdk/toolchain/patches/gcc-5.2.0-fix-gcc8.diff
+++ b/sdk/toolchain/patches/gcc-5.2.0-fix-gcc8.diff
@@ -1,0 +1,93 @@
+From 94801184df727b94bf7b8d64b1f98a22f51325d7 Mon Sep 17 00:00:00 2001
+From: Elliot Saba <staticfloat@gmail.com>
+Date: Mon, 22 Apr 2019 19:58:09 -0400
+Subject: [PATCH] Remove double `tempate <>` declarations in `wide-int.h`
+
+This fixes compilation of GCC 5.2.0 with very recent compilers such as
+GCC 8.3.0, which would otherwise fail with errors such as `error: too
+many template-parameter-lists`
+---
+ gcc/wide-int.h | 10 ----------
+ 1 file changed, 10 deletions(-)
+
+diff --git a/gcc/wide-int.h b/gcc/wide-int.h
+index 46f45453c015..9a71c4fea61b 100644
+--- a/gcc/wide-int.h
++++ b/gcc/wide-int.h
+@@ -365,21 +365,18 @@ namespace wi
+      inputs.  Note that CONST_PRECISION and VAR_PRECISION cannot be
+      mixed, in order to give stronger type checking.  When both inputs
+      are CONST_PRECISION, they must have the same precision.  */
+-  template <>
+   template <typename T1, typename T2>
+   struct binary_traits <T1, T2, FLEXIBLE_PRECISION, FLEXIBLE_PRECISION>
+   {
+     typedef widest_int result_type;
+   };
+ 
+-  template <>
+   template <typename T1, typename T2>
+   struct binary_traits <T1, T2, FLEXIBLE_PRECISION, VAR_PRECISION>
+   {
+     typedef wide_int result_type;
+   };
+ 
+-  template <>
+   template <typename T1, typename T2>
+   struct binary_traits <T1, T2, FLEXIBLE_PRECISION, CONST_PRECISION>
+   {
+@@ -389,14 +386,12 @@ namespace wi
+ 			       <int_traits <T2>::precision> > result_type;
+   };
+ 
+-  template <>
+   template <typename T1, typename T2>
+   struct binary_traits <T1, T2, VAR_PRECISION, FLEXIBLE_PRECISION>
+   {
+     typedef wide_int result_type;
+   };
+ 
+-  template <>
+   template <typename T1, typename T2>
+   struct binary_traits <T1, T2, CONST_PRECISION, FLEXIBLE_PRECISION>
+   {
+@@ -406,7 +401,6 @@ namespace wi
+ 			       <int_traits <T1>::precision> > result_type;
+   };
+ 
+-  template <>
+   template <typename T1, typename T2>
+   struct binary_traits <T1, T2, CONST_PRECISION, CONST_PRECISION>
+   {
+@@ -417,7 +411,6 @@ namespace wi
+ 			       <int_traits <T1>::precision> > result_type;
+   };
+ 
+-  template <>
+   template <typename T1, typename T2>
+   struct binary_traits <T1, T2, VAR_PRECISION, VAR_PRECISION>
+   {
+@@ -881,7 +874,6 @@ generic_wide_int <storage>::dump () const
+ 
+ namespace wi
+ {
+-  template <>
+   template <typename storage>
+   struct int_traits < generic_wide_int <storage> >
+     : public wi::int_traits <storage>
+@@ -960,7 +952,6 @@ inline wide_int_ref_storage <SE>::wide_int_ref_storage (const T &x,
+ 
+ namespace wi
+ {
+-  template <>
+   template <bool SE>
+   struct int_traits <wide_int_ref_storage <SE> >
+   {
+@@ -1147,7 +1138,6 @@ class GTY(()) fixed_wide_int_storage
+ 
+ namespace wi
+ {
+-  template <>
+   template <int N>
+   struct int_traits < fixed_wide_int_storage <N> >
+   {

--- a/sdk/toolchain/patches/kos.diff
+++ b/sdk/toolchain/patches/kos.diff
@@ -961,4 +961,25 @@ diff -ruN kos/kernel/arch/dreamcast/include/dc/vec3f.h kos-patched/kernel/arch/d
  /** \brief  Macro to rotate a vector about its origin on the x, y plane.
  
      This macro is an inline assembly operation using the SH4's fast
-
+--- b/kernel/arch/dreamcast/kernel/init.c
++++ a/kernel/arch/dreamcast/kernel/init.c
+@@ -24,7 +24,7 @@
+ 
+ void _atexit_call_all();
+ 
+-#if __GNUC__ == 4
++#if __GNUC__ >= 4
+ #define _init init
+ #define _fini fini
+ #endif
+--- b/kernel/libc/koslib/Makefile
++++ a/kernel/libc/koslib/Makefile
+@@ -19,8 +19,6 @@
+ GCC_MAJORMINOR = $(basename $(KOS_GCCVER))
+ GCC_MAJOR = $(basename $(GCC_MAJORMINOR))
+ 
+-ifeq ($(strip $(GCC_MAJOR)), 3)
+ OBJS += crtbegin.o crtend.o
+-endif
+ 
+ include $(KOS_BASE)/Makefile.prefab


### PR DESCRIPTION
Also add buildscript for Fedora linux

Still I'm getting a configure error when building opus from kos-ports:
configure:3531: checking whether the C compiler works
configure:3553: kos-cc    conftest.c  >&5
/opt/toolchains/dc/sh-elf/lib/gcc/sh-elf/5.2.0/../../../../sh-elf/bin/ld: /usr/local/dc/kos/kos/lib/dreamcast/libkallisti.a(init.o): in function `arch_shutdown':
/usr/local/dc/kos/kos/kernel/arch/dreamcast/kernel/init.c:275: undefined reference to `__fini'
/opt/toolchains/dc/sh-elf/lib/gcc/sh-elf/5.2.0/../../../../sh-elf/bin/ld: /usr/local/dc/kos/kos/lib/dreamcast/libkallisti.a(init.o): in function `arch_main':
/usr/local/dc/kos/kos/kernel/arch/dreamcast/kernel/init.c:227: undefined reference to `__init'
collect2: error: ld returned 1 exit status
configure:3557: $? = 1
configure:3595: result: no

Somehow static library libkallisti.a has a undefined reference to __fini and __init ?
Any help would be nice!