### PR TITLE
Toolchain does not require crtbegin.o and crtend.o afterall

### DIFF
--- a/sdk/toolchain/patches/kos.diff
+++ b/sdk/toolchain/patches/kos.diff
@@ -771,23 +771,6 @@ index 643c5a1..9a566cd 100644
  
      if(img == NULL) {
          dbglog(DBG_ERROR, "elf_load: can't allocate %d bytes for ELF load\n", sz);
-diff --git a/kernel/libc/koslib/Makefile b/kernel/libc/koslib/Makefile
-index 6fdc05f..96cd5bc 100644
---- a/kernel/libc/koslib/Makefile
-+++ b/kernel/libc/koslib/Makefile
-@@ -18,8 +18,8 @@ OBJS = abort.o byteorder.o memset2.o memset4.o memcpy2.o memcpy4.o \
- GCC_MAJORMINOR = $(basename $(KOS_GCCVER))
- GCC_MAJOR = $(basename $(GCC_MAJORMINOR))
- 
--ifneq ($(strip $(GCC_MAJOR)), 4)
--OBJS += crtbegin.o crtend.o
--endif
-+#ifneq ($(strip $(GCC_MAJOR)), 4)
-+#OBJS += crtbegin.o crtend.o
-+#endif
- 
- include $(KOS_BASE)/Makefile.prefab
-
 diff -ruN a/addons/libppp/Makefile b/addons/libppp/Makefile
 --- a/addons/libppp/Makefile	2017-02-02 23:29:14.000000000 +0200
 +++ b/addons/libppp/Makefile	2018-12-24 20:57:27.000000000 +0200
@@ -972,14 +955,3 @@ diff -ruN kos/kernel/arch/dreamcast/include/dc/vec3f.h kos-patched/kernel/arch/d
  #define _init init
  #define _fini fini
  #endif
---- b/kernel/libc/koslib/Makefile
-+++ a/kernel/libc/koslib/Makefile
-@@ -19,8 +19,6 @@
- GCC_MAJORMINOR = $(basename $(KOS_GCCVER))
- GCC_MAJOR = $(basename $(GCC_MAJORMINOR))
- 
--ifeq ($(strip $(GCC_MAJOR)), 3)
- OBJS += crtbegin.o crtend.o
--endif
- 
- include $(KOS_BASE)/Makefile.prefab


### PR DESCRIPTION
Due to this commit: https://github.com/KallistiOS/KallistiOS/commit/93175a99ec9211d7e1c6983be93547bb0c418fea
We don't need to patch the kernel/libc/koslib/Makefile any longer.
Because now they're only built when using gcc 3, which does not apply for us.

Tested again building the complete toolchain from a clean state (by also removing /opt/toolchain and /usr/local/dc first).