### PR TITLE
ciso: improved portability

### DIFF
--- a/sdk/bin/src/ciso/.gitignore
+++ b/sdk/bin/src/ciso/.gitignore
@@ -1,0 +1,3 @@
+# build artifacts
+ciso
+*.o

--- a/sdk/bin/src/ciso/Makefile
+++ b/sdk/bin/src/ciso/Makefile
@@ -1,28 +1,30 @@
 
-LBITS := $(shell getconf LONG_BIT)
-ifeq ($(LBITS),64)
-INCS = -I/usr/include/x86_64-linux-gnu -I/usr/include/$(gcc -print-multiarch)
-LIBS = -L/usr/lib32
-CC = gcc -m32 $(INCS)
-LD = gcc -m32 $(LIBS)
-else
-CC = gcc
-LD = gcc
-endif
+CFLAGS ?= -O2  # can be overriden by environment variable
+DEBUGFLAGS = -g -Wall -Wextra -Wconversion -Wcast-qual -Wcast-align -Wdeclaration-after-statement -Werror
+LDLIBS  = -lz -llzo2
 
 INSTALL = install
 DESTDIR = ../..
 
+.PHONY: release
+release : CPPFLAGS += -DNDEBUG
+release : ciso
+
+.PHONY: all
 all : ciso
-ciso : ciso.o
-	$(LD) -o ciso ciso.o -lz -llzo2
 
-ciso.o : ciso.c
-	$(CC) -o ciso.o -c ciso.c
+.PHONY: debug
+debug: ciso-debug
 
+.PHONY: ciso-debug
+ciso-debug: CFLAGS = $(DEBUGFLAGS)
+ciso-debug: ciso
+
+.PHONY: install
 install : ciso
 	$(INSTALL) -m 755 ciso $(DESTDIR)/ciso
 
+.PHONY: clean
 clean:
-	rm -rf *.o
-	rm -rf ciso
+	$(RM) *.o
+	$(RM) ciso

--- a/sdk/bin/src/ciso/ciso.c
+++ b/sdk/bin/src/ciso/ciso.c
@@ -21,43 +21,255 @@
 */
 
 
+/****************************************************************************
+	Dependencies
+****************************************************************************/
 #include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include <stdlib.h>    // abort
+#include <string.h>    // printf
+#include <assert.h>
 #include <memory.h>
-#include <zlib.h>               /* /usr(/local)/include/zlib.h */
+#include <zlib.h>
 #include <zconf.h>
 #include <lzo/lzo1x.h>
 #include "ciso.h"
 
-static const char *fname_in,*fname_out;
-static FILE *fin,*fout;
-static z_stream z;
 
-static unsigned int *index_buf = NULL;
-static unsigned int *crc_buf = NULL;
-static unsigned char *block_buf1 = NULL;
-static unsigned char *block_buf2 = NULL;
 
 /****************************************************************************
-	compress ISO to CSO
+	Macros
 ****************************************************************************/
+#define END(...) { \
+	fprintf(stderr, "" __VA_ARGS__); \
+	fprintf(stderr, " \n"); \
+	abort(); \
+}
 
-static CISO_H ciso;
-static int ciso_total_block;
-static int is_ziso = 0;
 
-unsigned long long check_file_size(FILE *fp)
+
+/****************************************************************************
+	Utilities
+****************************************************************************/
+/* This function is necessarily successful if it returns */
+static FILE* fopen_orDie(const char* fname, const char* mode)
 {
-	unsigned long long pos;
+	FILE* const f = fopen(fname, mode);
+	if (f==NULL) END("can't open '%s' with mode '%s'", fname, mode);
+	return f;
+}
 
-	if( fseek(fp,0,SEEK_END) < 0)
-		return -1;
+/* This function is necessarily successful if it returns */
+static size_t fread_orDie(void* buf, size_t eltSize, size_t nbElts, FILE* f)
+{
+	size_t const nbEltsRead = fread(buf, eltSize, nbElts, f);
+	if (nbEltsRead != nbElts) END("error reading data");
+	return nbEltsRead;
+}
+
+/* This function is necessarily successful if it returns */
+static size_t fwrite_orDie(const void* buf, size_t eltSize, size_t nbElts, FILE* f)
+{
+	size_t const nbEltsWritten = fwrite(buf, eltSize, nbElts, f);
+	if (nbEltsWritten != nbElts) END("error writing data");
+	return nbEltsWritten;
+}
+
+/* This function is necessarily successful if it returns */
+static void fseek_orDie(FILE* f, long int offset, int whence)
+{
+	int const res = fseek(f, offset, whence);
+	if (res != 0) END("error seeking into file");
+}
+
+
+
+/****************************************************************************
+	decompress CSO to ISO
+****************************************************************************/
+static void decomp_ciso(const char* fname_out, const char* fname_in)
+{
+	FILE* const fin = fopen_orDie(fname_in, "rb");
+	FILE* const fout = fopen_orDie(fname_out, "wb");
+
+	CISO_H ciso;
+	z_stream z;
+	int ciso_total_block;
+
+	uint32_t *index_buf;
+	unsigned char *block_buf1;
+	unsigned char *block_buf2;
+
+	/* read header */
+	fread_orDie(&ciso, 1, sizeof(ciso), fin);
+
+	/* check header */
+	if (
+		(ciso.magic[0] != 'Z' && ciso.magic[0] != 'C') ||
+		ciso.magic[1] != 'I' ||
+		ciso.magic[2] != 'S' ||
+		ciso.magic[3] != 'O' ||
+		ciso.block_size == 0 ||
+		ciso.total_bytes == 0
+	)
+	{
+		END("ciso file format error");
+	}
+
+	{	uint64_t const ctb64 = ciso.total_bytes / ciso.block_size;
+		assert(ctb64 < INT_MAX);
+		ciso_total_block = (int)ctb64;
+	}
+
+	/* allocate index block */
+	{
+		size_t const index_size = (size_t)(ciso_total_block + 1 ) * sizeof(uint32_t);
+		index_buf  = malloc(index_size);
+		block_buf1 = malloc(ciso.block_size*2);
+		block_buf2 = malloc(ciso.block_size*2);
+
+		if( !index_buf || !block_buf1 || !block_buf2 )
+			END("Can't allocate memory %d and %d x2",
+				(int)index_size, (int)ciso.block_size*2);
+
+		/* read index block */
+		fread_orDie(index_buf, 1, index_size, fin);
+	}
+
+	/* show info */
+	printf("Decompress '%s' to '%s' \n", fname_in, fname_out);
+	printf("Total File Size %ld bytes\n", (long)ciso.total_bytes);
+	printf("block size      %d  bytes\n", (int)ciso.block_size);
+	printf("total blocks    %d  blocks\n", ciso_total_block);
+	printf("index align     %d\n", 1<<ciso.align);
+	printf("type  %s\n", ciso.magic[0] == 'Z' ? "ZISO" : "CISO");
+
+	if(ciso.magic[0] == 'Z') {
+		if(lzo_init() != LZO_E_OK) END("lzo_init() failed");
+	} else {
+		/* init zlib */
+		z.zalloc = Z_NULL;
+		z.zfree  = Z_NULL;
+		z.opaque = Z_NULL;
+	}
+
+	/* decompress data */
+	{
+		int percent_period = ciso_total_block / 100;
+		int percent_cnt = 0;
+		unsigned index, plain;
+		long int read_pos;
+
+		int block;
+		for(block = 0;block < ciso_total_block ; block++)
+		{
+			size_t read_size;
+			size_t cmp_size;
+
+			if(--percent_cnt<=0)
+			{
+				percent_cnt = percent_period;
+				printf("decompress %d%%\r",block / percent_period);
+			}
+
+			if(ciso.magic[0] == 'C')  {
+				if (inflateInit2(&z,-15) != Z_OK)
+					END("deflateInit : %s\n", (z.msg) ? z.msg : "???");
+			}
+
+			/* check index */
+			index  = index_buf[block];
+			plain  = index & 0x80000000;
+			index  &= 0x7fffffff;
+			assert((LONG_MAX >> ciso.align) > index);  // check overflow
+			read_pos = index << (ciso.align);
+
+			if(plain)
+			{
+				read_size = ciso.block_size;
+			}
+			else
+			{
+				unsigned int const index2 = index_buf[block+1] & 0x7fffffff;
+				read_size = (index2-index) << (ciso.align);
+			}
+
+			fseek_orDie(fin, read_pos, SEEK_SET);
+
+			z.avail_in  = (uInt)fread_orDie(block_buf2, 1, read_size , fin);
+
+			if(z.avail_in != read_size)
+				END("block=%d : read error", block);
+
+			if(plain)
+			{
+				memcpy(block_buf1,block_buf2,read_size);
+				cmp_size = read_size;
+			}
+			else
+			{
+				if(ciso.magic[0] == 'Z') {
+					unsigned long lzolen;
+					int const status = lzo1x_decompress(block_buf2, z.avail_in, block_buf1, &lzolen, NULL);
+					cmp_size = lzolen;
+					z.avail_out = ciso.block_size;
+
+					if(status != LZO_E_OK) END("block %d:lzo1x_decompress: %d", block, status);
+
+				} else {
+					int status;
+
+					z.next_out  = block_buf1;
+					z.avail_out = ciso.block_size;
+					z.next_in   = block_buf2;
+
+					status = inflate(&z, Z_FULL_FLUSH);
+
+					if (status != Z_STREAM_END)
+						END("block %d:inflate : %s[%d]", block,(z.msg) ? z.msg : "error", status);
+
+					cmp_size = ciso.block_size - z.avail_out;
+				}
+
+				if (cmp_size != ciso.block_size)
+					END("block %d : block size error %d != %d",
+						block, (int)cmp_size, (int)ciso.block_size);
+			}
+			/* write decompressed block */
+			fwrite_orDie(block_buf1, 1,cmp_size , fout);
+
+			if(ciso.magic[0] == 'C')  {
+				/* term zlib */
+				if (inflateEnd(&z) != Z_OK)
+					END("inflateEnd : %s\n", (z.msg) ? z.msg : "error");
+			}
+		}
+	}
+
+	printf("ciso decompress completed\n");
+
+	/* clean out */
+	free(index_buf);
+	free(block_buf1);
+	free(block_buf2);
+	fclose(fin);
+	fclose(fout);
+}
+
+/****************************************************************************
+	compress ISO
+****************************************************************************/
+/* if this function returns, it's necessary successful */
+static CISO_H init_ciso_header(FILE* fp, int is_ziso)
+{
+	CISO_H ciso;
+	long int pos;
+
+	fseek_orDie(fp, 0, SEEK_END);
 	pos = ftell(fp);
-	if(pos==-1) return pos;
+	if (pos==-1L) END("Cannot determine file size; terminating ... \n");
 
 	/* init ciso header */
-	memset(&ciso,0,sizeof(ciso));
+	memset(&ciso, 0, sizeof(ciso));
 
 	if(is_ziso) {
 		ciso.magic[0] = 'Z';
@@ -70,266 +282,56 @@ unsigned long long check_file_size(FILE *fp)
 	ciso.ver      = 0x01;
 
 	ciso.block_size  = 0x800; /* ISO9660 one of sector */
-	ciso.total_bytes = pos;
+	assert(pos > 0);
+	ciso.total_bytes = (uint64_t)pos;
 #if 0
 	/* align >0 has bug */
 	for(ciso.align = 0 ; (ciso.total_bytes >> ciso.align) >0x80000000LL ; ciso.align++);
 #endif
 
-	ciso_total_block = pos / ciso.block_size ;
+	fseek_orDie(fp,0,SEEK_SET);
 
-	fseek(fp,0,SEEK_SET);
-
-	return pos;
+	return ciso;
 }
 
-/****************************************************************************
-	decompress CSO to ISO
-****************************************************************************/
-int decomp_ciso(void)
+static void comp_ciso(int level, int is_ziso, int no_comp_diff,
+                     const char* fname_out, const char* fname_in)
 {
-	unsigned long long file_size;
-	unsigned int index , index2;
-	unsigned long long read_pos , read_size;
-	int total_sectors;
-	int index_size;
+	FILE* const fin = fopen_orDie(fname_in, "rb");
+	FILE* const fout = fopen_orDie(fname_out, "wb");
+
+	unsigned long long write_pos;
 	int block;
-	unsigned char buf4[4];
+	unsigned char buf4[64] = {0};
 	int cmp_size;
-	int status;
 	int percent_period;
 	int percent_cnt;
-	int plain;
-	unsigned long lzolen;
+	int align_b, align_m;
 
-	/* read header */
-	if( fread(&ciso, 1, sizeof(ciso), fin) != sizeof(ciso) )
-	{
-		printf("file read error\n");
-		return 1;
-	}
+	z_stream z;
+	lzo_voidp wrkmem = NULL;
 
-	/* check header */
-	if(
-		(ciso.magic[0] != 'Z' && ciso.magic[0] != 'C') ||
-		ciso.magic[1] != 'I' ||
-		ciso.magic[2] != 'S' ||
-		ciso.magic[3] != 'O' ||
-		ciso.block_size ==0  ||
-		ciso.total_bytes == 0
-	)
-	{
-		printf("ciso file format error\n");
-		return 1;
-	}
-	 
-	ciso_total_block = ciso.total_bytes / ciso.block_size;
+	CISO_H ciso = init_ciso_header(fin, is_ziso);
+	int const ciso_total_block = (int)(ciso.total_bytes / ciso.block_size);
 
 	/* allocate index block */
-	index_size = (ciso_total_block + 1 ) * sizeof(unsigned long);
-	index_buf  = malloc(index_size);
-	block_buf1 = malloc(ciso.block_size*2);
-	block_buf2 = malloc(ciso.block_size*2);
+	size_t const index_size = (size_t)(ciso_total_block + 1 ) * sizeof(uint32_t);
+
+	uint32_t* const index_buf  = calloc(1, index_size);
+	unsigned char* const block_buf1 = malloc(ciso.block_size*2);
+	unsigned char* const block_buf2 = malloc(ciso.block_size*2);
 
 	if( !index_buf || !block_buf1 || !block_buf2 )
-	{
-		printf("Can't allocate memory %d and %d x2\n", index_size, ciso.block_size*2);
-		return 1;
-	}
-	memset(index_buf,0,index_size);
-
-	/* read index block */
-	if( fread(index_buf, 1, index_size, fin) != index_size )
-	{
-		printf("file read error\n");
-		return 1;
-	}
-
-	/* show info */
-	printf("Decompress '%s' to '%s'\n",fname_in,fname_out);
-	printf("Total File Size %ld bytes\n",ciso.total_bytes);
-	printf("block size      %d  bytes\n",ciso.block_size);
-	printf("total blocks    %d  blocks\n",ciso_total_block);
-	printf("index align     %d\n",1<<ciso.align);
-	printf("type  %s\n", ciso.magic[0] == 'Z' ? "ZISO" : "CISO");
-
-	if(ciso.magic[0] == 'Z') {
-		if(lzo_init() != LZO_E_OK) {
-			printf("lzo_init() failed\n");
-			return 1;
-		}
-	} else {
-
-		/* init zlib */
-		z.zalloc = Z_NULL;
-		z.zfree  = Z_NULL;
-		z.opaque = Z_NULL;
-	
-	}
-
-	/* decompress data */
-	percent_period = ciso_total_block/100;
-	percent_cnt = 0;
-
-	for(block = 0;block < ciso_total_block ; block++)
-	{
-		if(--percent_cnt<=0)
-		{
-			percent_cnt = percent_period;
-			printf("decompress %d%%\r",block / percent_period);
-		}
-		
-		if(ciso.magic[0] == 'C')  {
-
-			if (inflateInit2(&z,-15) != Z_OK)
-			{
-				printf("deflateInit : %s\n", (z.msg) ? z.msg : "???");
-				return 1;
-			}
-		}
-
-		/* check index */
-		index  = index_buf[block];
-		plain  = index & 0x80000000;
-		index  &= 0x7fffffff;
-		read_pos = index << (ciso.align);
-		
-		if(plain)
-		{
-			read_size = ciso.block_size;
-		}
-		else
-		{
-			index2 = index_buf[block+1] & 0x7fffffff;
-			read_size = (index2-index) << (ciso.align);
-		}
-		
-		fseek(fin,read_pos,SEEK_SET);
-		
-		z.avail_in  = fread(block_buf2, 1, read_size , fin);
-		
-		if(z.avail_in != read_size)
-		{
-			printf("block=%d : read error\n",block);
-			return 1;
-		}
-
-		if(plain)
-		{
-			memcpy(block_buf1,block_buf2,read_size);
-			cmp_size = read_size;
-		}
-		else
-		{
-
-			if(ciso.magic[0] == 'Z') {
-				
-				z.avail_out = ciso.block_size;
-				status = lzo1x_decompress(block_buf2, z.avail_in, block_buf1, &lzolen, NULL);
-				cmp_size = lzolen;
-				
-				if(status != LZO_E_OK) {
-					printf("block %d:lzo1x_decompress: %d\n", status);
-					return 1;
-				}
-				
-			} else {
-				
-				z.next_out  = block_buf1;
-				z.avail_out = ciso.block_size;
-				z.next_in   = block_buf2;
-
-				status = inflate(&z, Z_FULL_FLUSH);
-				
-				if (status != Z_STREAM_END)
-				/*if (status != Z_OK)*/
-				{
-					printf("block %d:inflate : %s[%d]\n", block,(z.msg) ? z.msg : "error",status);
-					return 1;
-				}
-				
-				cmp_size = ciso.block_size - z.avail_out;
-			}
-			
-			if(cmp_size != ciso.block_size)
-			{
-				printf("block %d : block size error %d != %d\n",block,cmp_size , ciso.block_size);
-				return 1;
-			}
-		}
-		/* write decompressed block */
-		if(fwrite(block_buf1, 1,cmp_size , fout) != cmp_size)
-		{
-			printf("block %d : Write error\n",block);
-			return 1;
-		}
-
-		if(ciso.magic[0] == 'C')  {
-			/* term zlib */
-			if (inflateEnd(&z) != Z_OK)
-			{
-				printf("inflateEnd : %s\n", (z.msg) ? z.msg : "error");
-				return 1;
-			}
-		}
-	}
-
-	printf("ciso decompress completed\n");
-	return 0;
-}
-
-/****************************************************************************
-	compress ISO
-****************************************************************************/
-int comp_ciso(int level, int no_comp_diff)
-{
-	unsigned long long file_size;
-	unsigned long long write_pos;
-	int total_sectors;
-	int index_size;
-	int block;
-	unsigned char buf4[64];
-	int cmp_size;
-	int status;
-	int percent_period;
-	int percent_cnt;
-	int align,align_b,align_m;
-	lzo_voidp wrkmem;
-	unsigned long lzolen;
-	
-
-	file_size = check_file_size(fin);
-	if(file_size<0)
-	{
-		printf("Can't get file size\n");
-		return 1;
-	}
-
-	/* allocate index block */
-	index_size = (ciso_total_block + 1 ) * sizeof(unsigned long);
-	index_buf  = malloc(index_size);
-	crc_buf    = malloc(index_size);
-	block_buf1 = malloc(ciso.block_size*2);
-	block_buf2 = malloc(ciso.block_size*2);
-
-	if( !index_buf || !crc_buf || !block_buf1 || !block_buf2 )
-	{
-		printf("Can't allocate memory\n");
-		return 1;
-	}
-	memset(index_buf,0,index_size);
-	memset(crc_buf,0,index_size);
-	memset(buf4,0,sizeof(buf4));
+		END("Can't allocate memory\n");
 
 	if(is_ziso)  {
-		if(lzo_init() != LZO_E_OK) {
-			printf("lzo_init() failed\n");
-			return 1;
-		}
-		
+		if(lzo_init() != LZO_E_OK)
+			END("lzo_init() failed\n");
+
 		//wrkmem = (lzo_voidp) malloc(LZO1X_1_MEM_COMPRESS);
 		wrkmem = (lzo_voidp) malloc(LZO1X_999_MEM_COMPRESS);
-		
+		if (wrkmem==NULL) END("memory allocation error");
+
 	} else {
 		/* init zlib */
 		z.zalloc = Z_NULL;
@@ -338,18 +340,19 @@ int comp_ciso(int level, int no_comp_diff)
 	}
 
 	/* show info */
-	printf("Compress '%s' to '%s'\n",fname_in,fname_out);
-	printf("Total File Size %ld bytes\n",ciso.total_bytes);
-	printf("block size      %d  bytes\n",ciso.block_size);
-	printf("index align     %d\n",1<<ciso.align);
-	printf("compress level  %d\n",level);
+	printf("Compress '%s' to '%s' \n", fname_in, fname_out);
+	printf("Total File Size %ld bytes\n", (long)ciso.total_bytes);
+	printf("block size      %d  bytes\n", (int)ciso.block_size);
+	printf("index align     %d\n", 1<<ciso.align);
+	printf("compress level  %d\n", level);
 	printf("type  %s\n", is_ziso ? "ZISO" : "CISO");
 
 	/* write header block */
-	fwrite(&ciso,1,sizeof(ciso),fout);
+	fwrite_orDie(&ciso, 1, sizeof(ciso), fout);
 
-	/* dummy write index block */
-	fwrite(index_buf,1,index_size,fout);
+	/* skip index block */
+	assert(index_size < LONG_MAX);
+	fseek_orDie(fout, (long int)index_size, SEEK_CUR);
 
 	write_pos = sizeof(ciso) + index_size;
 
@@ -357,135 +360,119 @@ int comp_ciso(int level, int no_comp_diff)
 	percent_period = ciso_total_block/100;
 	percent_cnt    = ciso_total_block/100;
 
-	align_b = 1<<(ciso.align);
-	align_m = align_b -1;
+	align_b = 1 << ciso.align;
+	align_m = align_b - 1;
 
 	for(block = 0;block < ciso_total_block ; block++)
 	{
 		if(--percent_cnt<=0)
 		{
 			percent_cnt = percent_period;
-			printf("compress %3d%% avarage rate %3d%%\r"
-				,block / percent_period
-				,block==0 ? 0 : 100*write_pos/(block*0x800));
+			printf("compress %3d%% avarage rate %3d%%\r",
+				block / percent_period,
+				(block==0) ? 0 : (int)(100*write_pos/((unsigned long long)block*0x800)) );
 		}
 
 		if(!is_ziso)  {
 			if (deflateInit2(&z, level , Z_DEFLATED, -15,8,Z_DEFAULT_STRATEGY) != Z_OK)
-			{
-				printf("deflateInit : %s\n", (z.msg) ? z.msg : "???");
-				return 1;
-			}
+				END("deflateInit : %s\n", (z.msg) ? z.msg : "???");
 		}
 
 		/* write align */
-		align = (int)write_pos & align_m;
-		if(align)
 		{
-			align = align_b - align;
-			if(fwrite(buf4,1,align, fout) != align)
+			int align = (int)write_pos & align_m;
+			if (align)
 			{
-				printf("block %d : Write error\n",block);
-				return 1;
+				align = align_b - align;
+				assert(align >= 0);
+				fwrite_orDie(buf4, 1, (size_t)align, fout);
+				write_pos = write_pos + (unsigned long long)align;
 			}
-			write_pos += align;
 		}
 
 		/* mark offset index */
-		index_buf[block] = write_pos>>(ciso.align);
+		index_buf[block] = (uint32_t)(write_pos >> ciso.align);
 
 		/* read buffer */
 		z.next_out  = block_buf2;
 		z.avail_out = ciso.block_size*2;
 		z.next_in   = block_buf1;
-		z.avail_in  = fread(block_buf1, 1, ciso.block_size , fin);
+		z.avail_in  = (uInt)fread_orDie(block_buf1, 1, ciso.block_size , fin);
 
-		if(z.avail_in != ciso.block_size)
-		{
-			printf("block=%d : read error\n",block);
-			return 1;
-		}
-		
 		if(is_ziso)  {
-			
+			unsigned long lzolen;
+
 			//status = lzo1x_1_compress(block_buf1, z.avail_in, block_buf2, &lzolen, wrkmem);
-			status = lzo1x_999_compress(block_buf1, z.avail_in, block_buf2, &lzolen, wrkmem);
-			
+			int const status =
+				lzo1x_999_compress(block_buf1, z.avail_in, block_buf2, &lzolen, wrkmem);
+
 			//printf("in: %d out: %d\n", z.avail_in, lzolen);
-			
-			if (status != LZO_E_OK) {
-				/* this should NEVER happen */
-				printf("compression failed: lzo1x_1_compress: %d\n", status);
-				return 1;
-			}
-			
-			cmp_size = lzolen;
-			
+
+			if (status != LZO_E_OK)
+				END("compression failed: lzo1x_1_compress: %d\n", status);
+
+			assert(lzolen < INT_MAX);
+			cmp_size = (int)lzolen;
+
 		} else {
 
-			/* compress block
-			status = deflate(&z, Z_FULL_FLUSH);*/
-			status = deflate(&z, Z_FINISH);
+			/* compress block */
+			int const status = deflate(&z, Z_FINISH);
 			if (status != Z_STREAM_END)
-		/*	if (status != Z_OK) */
-			{
-				printf("block %d:deflate : %s[%d]\n", block,(z.msg) ? z.msg : "error",status);
-				return 1;
-			}
-			cmp_size = ciso.block_size*2 - z.avail_out;
+				END("block %d:deflate : %s[%d]\n", block,(z.msg) ? z.msg : "error", status);
+			cmp_size = (int)(ciso.block_size*2 - z.avail_out);
 		}
 
 		/* choise plain / compress */
-		if(cmp_size >= (ciso.block_size - no_comp_diff))
+		if (cmp_size >= ((int)ciso.block_size - no_comp_diff))
 		{
-			cmp_size = ciso.block_size;
-			memcpy(block_buf2,block_buf1,cmp_size);
+			cmp_size = (int)ciso.block_size;
+			memcpy(block_buf2, block_buf1, (size_t)cmp_size);
 			/* plain block mark */
 			index_buf[block] |= 0x80000000;
 		}
 
 		/* write compressed block */
-		if(fwrite(block_buf2, 1,cmp_size , fout) != cmp_size)
-		{
-			printf("block %d : Write error\n",block);
-			return 1;
-		}
+		fwrite_orDie(block_buf2, 1, (size_t)cmp_size, fout);
 
 		/* mark next index */
-		write_pos += cmp_size;
+		write_pos = write_pos + (unsigned long long)cmp_size;
 
 		if(!is_ziso)  {
 			/* term zlib */
 			if (deflateEnd(&z) != Z_OK)
-			{
-				printf("deflateEnd : %s\n", (z.msg) ? z.msg : "error");
-				return 1;
-			}
+				END("deflateEnd : %s\n", (z.msg) ? z.msg : "error");
 		}
 	}
 
 	/* last position (total size)*/
-	index_buf[block] = write_pos>>(ciso.align);
+	index_buf[block] = (uint32_t)(write_pos >> ciso.align);
 
-	/* write header & index block */
-	fseek(fout,sizeof(ciso),SEEK_SET);
-	fwrite(index_buf,1,index_size,fout);
+	/* write index block */
+	fseek_orDie(fout, sizeof(ciso), SEEK_SET);
+	fwrite_orDie(index_buf, 1, index_size, fout);
 
-	printf("ciso compress completed , total size = %8d bytes , rate %d%%\n"
-		,(int)write_pos,(int)(write_pos*100/ciso.total_bytes));
-	return 0;
+	printf("ciso compression completed ; total size = %8d bytes , rate %d%% \n",
+			(int)write_pos, (int)(write_pos*100/ciso.total_bytes));
+
+	/* clean out */
+	free(index_buf);
+	free(block_buf1);
+	free(block_buf2);
+	fclose(fin);
+	fclose(fout);
 }
 
+
 /****************************************************************************
-	main
+	command line
 ****************************************************************************/
 int main(int argc, char *argv[])
 {
 	int level;
-	int result;
-	int no_comp_diff = 48;
+	int no_comp_diff = 48;  /* minimym gain required per block */
 
-	printf("ISO9660 comp/dec to/from CISO/ZISO v1.1 by SWAT\n");
+	printf("ISO9660 comp/dec to/from CISO/ZISO v1.1 by SWAT \n");
 
 	if (argc < 5)
 	{
@@ -501,41 +488,20 @@ int main(int argc, char *argv[])
 		return 1;
 	}
 
-	fname_in = argv[3];
-	fname_out = argv[4];
-
 	if(argc > 5) {
 		no_comp_diff = atoi(argv[5]);
 	}
-	
-	if(!strcmp("lzo", argv[1])) {
-		is_ziso = 1;
-	}
 
-	if ((fin = fopen(fname_in, "rb")) == NULL)
 	{
-		printf("Can't open %s\n", fname_in);
-		return 1;
+		const char* const fname_in = argv[3];
+		const char* const fname_out = argv[4];
+		int const is_ziso = !strcmp("lzo", argv[1]);
+
+		if(level==0)
+			decomp_ciso(fname_out, fname_in);
+		else
+			comp_ciso(level, is_ziso, no_comp_diff, fname_out, fname_in);
 	}
-	if ((fout = fopen(fname_out, "wb")) == NULL)
-	{
-		printf("Can't create %s\n", fname_out);
-		return 1;
-	}
 
-	if(level==0)
-		result = decomp_ciso();
-	else
-		result = comp_ciso(level, no_comp_diff);
-
-	/* free memory */
-	if(index_buf) free(index_buf);
-	if(crc_buf) free(crc_buf);
-	if(block_buf1) free(block_buf1);
-	if(block_buf2) free(block_buf2);
-
-	/* close files */
-	fclose(fin);
-	fclose(fout);
-	return result;
+	return 0;
 }

--- a/sdk/bin/src/ciso/ciso.h
+++ b/sdk/bin/src/ciso/ciso.h
@@ -24,29 +24,34 @@
 #ifndef __CISO_H__
 #define __CISO_H__
 /*
-	complessed ISO(9660) header format
+	compressed ISO(9660) header format
 */
+
+#include <stdint.h>   /*uintx_t */
+
 typedef struct ciso_header
 {
 	unsigned char magic[4];			/* +00 : 'C','I','S','O'                 */
-	unsigned long header_size;		/* +04 : header size (==0x18)            */
-	unsigned long long total_bytes;	/* +08 : number of original data size    */
-	unsigned long block_size;		/* +10 : number of compressed block size */
+	uint32_t header_size;			/* +04 : header size (==0x18)            */
+	uint64_t total_bytes;			/* +08 : number of original data size    */
+	uint32_t block_size;			/* +10 : number of compressed block size */
 	unsigned char ver;				/* +14 : version 01                      */
 	unsigned char align;			/* +15 : align of index value            */
 	unsigned char rsv_06[2];		/* +16 : reserved                        */
 #if 0
+// For documentation
+// Note : a link to a spec of the format would be welcomed
 // INDEX BLOCK
-	unsigned int index[0];			/* +18 : block[0] index                  */
-	unsigned int index[1];			/* +1C : block[1] index                  */
+	uint32_t index[0];			/* +18 : block[0] index                  */
+	uint32_t index[1];			/* +1C : block[1] index                  */
              :
              :
-	unsigned int index[last];		/* +?? : block[last]                     */
-	unsigned int index[last+1];		/* +?? : end of last data point          */
+	uint32_t index[last];		/* +?? : block[last]                     */
+	uint32_t index[last+1];		/* +?? : end of last data point          */
 // DATA BLOCK
 	unsigned char data[];			/* +?? : compressed or plain sector data */
 #endif
-}CISO_H;
+} CISO_H;   // total size should be checked with a static assert
 
 /*
 note:
@@ -59,5 +64,9 @@ if(index[n]&0x80000000)
 else
   // read file_size_sector[n] bytes and decompress data
 */
+
+/* ensure that header size is correct (control unwanted padding) */
+enum { __ciso_static_assert = 1 / (sizeof(CISO_H) == 24) };
+
 
 #endif


### PR DESCRIPTION
Types and structures can have different size and alignment depending on target system.
The ciso.c utility was apparently designed to be compiled on Windows 32-bit.
Header and Indexes become different when compiled on Linux 64-bit,
resulting in format discrepancy.

The new code is more portable, and shall generate the same metadata on any little endian system.
It also fixes a few errors, and do a moderate clean up attempt by :
- removing usage of global variables
- reducing scope of some variables

The generated executable now produces exactly the same *.cso files as the pre-built Windows binary (compared using `md5sum`), even when compiled on Linux 64-bit mode.

Note : this code preserves the original idea of directly writing or reading the header structure at the beginning of the cso file.
However, it requires a little-endian CPU (big-endian cpus write large numbers differently).