### PR TITLE
Make inline function static to fix build with Os

### DIFF
--- a/src/vmu/vmu.c
+++ b/src/vmu/vmu.c
@@ -26,7 +26,7 @@ static void vmu_invert_bitmap(uint8 bitmap[192])
 			vmu_flip_bit(bitmap, x, y);
 }*/
 
-inline void vmu_set_bit(uint8 bitmap[192], uint8 x, uint8 y)
+static inline void vmu_set_bit(uint8 bitmap[192], uint8 x, uint8 y)
 	/* (0, 0) is upper-left corner */
 {
 	if (x < 48 && y < 32)


### PR DESCRIPTION
Fixes undefined reference to vmu_set_bit when building with Os (due to inlining).