### PR TITLE
Add Newlib 4.5.0 fastmem patch

### DIFF
--- a/sdk/toolchain/patches/newlib-4.5.0.20241231-fastmem.diff
+++ b/sdk/toolchain/patches/newlib-4.5.0.20241231-fastmem.diff
@@ -1,0 +1,1669 @@
+diff --color -ruN newlib-4.5.0.20241231/newlib/libc/machine/sh/memcpy.S newlib-4.5.0.20241231-kos/newlib/libc/machine/sh/memcpy.S
+--- newlib-4.5.0.20241231/newlib/libc/machine/sh/memcpy.S	2023-01-21 04:01:54
++++ newlib-4.5.0.20241231-kos/newlib/libc/machine/sh/memcpy.S	2023-04-21 19:00:00
+@@ -1,395 +1,1002 @@
+-!
+-! Fast SH memcpy
+-!
+-! by Toshiyasu Morita (tm@netcom.com)
+-! hacked by J"orn Rernnecke (joern.rennecke@superh.com) ("o for o-umlaut)
+-! SH5 code Copyright 2002 SuperH Ltd.
+-!
+-! Entry: ARG0: destination pointer
+-!        ARG1: source pointer
+-!        ARG3: byte count
+-!
+-! Exit:  RESULT: destination pointer
+-!        any other registers in the range r0-r7: trashed
+-!
+-! Notes: Usually one wants to do small reads and write a longword, but
+-!        unfortunately it is difficult in some cases to concatanate bytes
+-!        into a longword on the SH, so this does a longword read and small
+-!        writes.
+-!
+-! This implementation makes two assumptions about how it is called:
+-!
+-! 1.: If the byte count is nonzero, the address of the last byte to be
+-!     copied is unsigned greater than the address of the first byte to
+-!     be copied.  This could be easily swapped for a signed comparison,
+-!     but the algorithm used needs some comparison.
+-!
+-! 2.: When there are two or three bytes in the last word of an 11-or-more
+-!     bytes memory chunk to b copied, the rest of the word can be read
+-!     without side effects.
+-!     This could be easily changed by increasing the minumum size of
+-!     a fast memcpy and the amount subtracted from r7 before L_2l_loop be 2,
+-!     however, this would cost a few extra cyles on average.
+-!     For SHmedia, the assumption is that any quadword can be read in its
+-!     enirety if at least one byte is included in the copy.
+-!
++/*
++ * "memcpy" implementation of SuperH
++ *
++ * Copyright (C) 1999  Niibe Yutaka
++ * Copyright (c) 2002  STMicroelectronics Ltd
++ *   Modified from memcpy.S and micro-optimised for SH4
++ *   Stuart Menefy (stuart.menefy@st.com)
++ *
++ * Copyright (c) 2009  STMicroelectronics Ltd
++ *   Optimised using prefetching and 64bit data transfer via FPU
++ *   Author: Giuseppe Cavallaro <peppe.cavallaro@st.com>
++ */
+ 
++/*
++ * void *memcpy(void *dst, const void *src, size_t n);
++ *
++ * It is assumed that there is no overlap between src and dst.
++ * If there is an overlap, then the results are undefined.
++ */
++
+ #include "asm.h"
+ 
+-ENTRY(memcpy)
++#if defined (__LITTLE_ENDIAN__) && defined (__SH_FPU_ANY__)
++#define	MEMCPY_USES_FPU
++/* Use paired single precision load or store mode for 64-bit tranfering.
++ * FPSCR.SZ=1,FPSCR.SZ=0 is well defined on both SH4-200 and SH4-300.
++ * Currenlty it has been only implemented and tested for little endian mode. */
++.macro FPU_SET_PAIRED_PREC
++	sts	fpscr, r7
++	mov	#0x10, r0	! PR=0 SZ=1
++	shll16	r0
++	lds	r0, fpscr
++.endm
++.macro RESTORE_FPSCR
++	lds	r7, fpscr
++.endm
++.macro DALLOC
++	! Cache allocate + store on dst-32.
++	add	#-32, r1
++	movca.l	r0, @r1
++	add	#32, r1
++.endm
+ 
+-#if __SHMEDIA__
++#endif
+ 
+-#define LDUAQ(P,O,D0,D1) ldlo.q P,O,D0; ldhi.q P,O+7,D1
+-#define STUAQ(P,O,D0,D1) stlo.q P,O,D0; sthi.q P,O+7,D1
+-#define LDUAL(P,O,D0,D1) ldlo.l P,O,D0; ldhi.l P,O+3,D1
+-#define STUAL(P,O,D0,D1) stlo.l P,O,D0; sthi.l P,O+3,D1
++	!
++	!	GHIJ KLMN OPQR -->  ...G HIJK LMNO PQR.
++	!
+ 
+-	ld.b r3,0,r63
+-	pta/l Large,tr0
+-	movi 25,r0
+-	bgeu/u r4,r0,tr0
+-	nsb r4,r0
+-	shlli r0,5,r0
+-	movi (L1-L0+63*32 + 1) & 0xffff,r1
+-	sub r1, r0, r0
+-L0:	ptrel r0,tr0
+-	add r2,r4,r5
+-	ptabs r18,tr1
+-	add r3,r4,r6
+-	blink tr0,r63
++	! Size is 16 or greater, and may have trailing bytes
+ 
+-	.balign 8
+-L1:
+-	/* 0 byte memcpy */
+-	blink tr1,r63
++	.balign	32
++.Lcase1:
++	! Read a long word and write a long word at once
++	! At the start of each iteration, r7 contains last long load
++	add	#-1,r5		!  79 EX
++	mov	r4,r2		!   5 MT (0 cycles latency)
+ 
+-L4_7:	/* 4..7 byte memcpy cntd. */
+-	stlo.l r2, 0, r0
+-	or r6, r7, r6
+-	sthi.l r5, -1, r6
+-	stlo.l r5, -4, r6
+-	blink tr1,r63
++	mov.l	@(r0,r5),r7	!  21 LS (2 cycles latency)
++	add	#-4,r5		!  50 EX
+ 
+-L2_3:	/* 2 or 3 byte memcpy cntd. */
+-	st.b r5,-1,r6
+-	blink tr1,r63
++	add	#7,r2		!  79 EX
++	!
++#ifdef __LITTLE_ENDIAN__
++	! 6 cycles, 4 bytes per iteration
++3:	mov.l	@(r0,r5),r1	!  21 LS (latency=2)	! NMLK
++	mov	r7, r3		!   5 MT (latency=0)	! RQPO
+ 
+-	/* 1 byte memcpy */
+-	ld.b r3,0,r0
+-	st.b r2,0,r0
+-	blink tr1,r63
++	cmp/hi	r2,r0		!  57 MT
++	shll16	r3		! 103 EX
+ 
+-L8_15:	/* 8..15 byte memcpy cntd. */
+-	stlo.q r2, 0, r0
+-	or r6, r7, r6
+-	sthi.q r5, -1, r6
+-	stlo.q r5, -8, r6
+-	blink tr1,r63
+-	
+-	/* 2 or 3 byte memcpy */
+-	ld.b r3,0,r0
+-	ld.b r2,0,r63
+-	ld.b r3,1,r1
+-	st.b r2,0,r0
+-	pta/l L2_3,tr0
+-	ld.b r6,-1,r6
+-	st.b r2,1,r1
+-	blink tr0, r63
++	mov	r1,r6		!   5 MT (latency=0)
++	shll8	r3		! 102 EX		! Oxxx
+ 
+-	/* 4 .. 7 byte memcpy */
+-	LDUAL (r3, 0, r0, r1)
+-	pta L4_7, tr0
+-	ldlo.l r6, -4, r7
+-	or r0, r1, r0
+-	sthi.l r2, 3, r0
+-	ldhi.l r6, -1, r6
+-	blink tr0, r63
++	shlr8	r6		! 106 EX		! xNML
++	mov	r1, r7		!   5 MT (latency=0)
+ 
+-	/* 8 .. 15 byte memcpy */
+-	LDUAQ (r3, 0, r0, r1)
+-	pta L8_15, tr0
+-	ldlo.q r6, -8, r7
+-	or r0, r1, r0
+-	sthi.q r2, 7, r0
+-	ldhi.q r6, -1, r6
+-	blink tr0, r63
++	or	r6,r3		!  82 EX		! ONML
++	bt/s	3b		! 109 BR
+ 
+-	/* 16 .. 24 byte memcpy */
+-	LDUAQ (r3, 0, r0, r1)
+-	LDUAQ (r3, 8, r8, r9)
+-	or r0, r1, r0
+-	sthi.q r2, 7, r0
+-	or r8, r9, r8
+-	sthi.q r2, 15, r8
+-	ldlo.q r6, -8, r7
+-	ldhi.q r6, -1, r6
+-	stlo.q r2, 8, r8
+-	stlo.q r2, 0, r0
+-	or r6, r7, r6
+-	sthi.q r5, -1, r6
+-	stlo.q r5, -8, r6
+-	blink tr1,r63
++	 mov.l	r3,@-r0		!  30 LS
++#else
++3:	mov.l	@(r0,r5),r1	!  21 LS (latency=2)	! KLMN
++	mov	r7,r3		!   5 MT (latency=0)	! OPQR
+ 
+-Large:
+-	ld.b r2, 0, r63
+-	pta/l  Loop_ua, tr1
+-	ori r3, -8, r7
+-	sub r2, r7, r22
+-	sub r3, r2, r6
+-	add r2, r4, r5
+-	ldlo.q r3, 0, r0
+-	addi r5, -16, r5
+-	movi 64+8, r27 // could subtract r7 from that.
+-	stlo.q r2, 0, r0
+-	sthi.q r2, 7, r0
+-	ldx.q r22, r6, r0
+-	bgtu/l r27, r4, tr1
++	cmp/hi	r2,r0		!  57 MT
++	shlr16	r3		! 107 EX
+ 
+-	addi r5, -48, r27
+-	pta/l Loop_line, tr0
+-	addi r6, 64, r36
+-	addi r6, -24, r19
+-	addi r6, -16, r20
+-	addi r6, -8, r21
++	shlr8	r3		! 106 EX		! xxxO
++	mov	r1,r6		!   5 MT (latency=0)
+ 
+-Loop_line:
+-	ldx.q r22, r36, r63
+-	alloco r22, 32
+-	addi r22, 32, r22
+-	ldx.q r22, r19, r23
+-	sthi.q r22, -25, r0
+-	ldx.q r22, r20, r24
+-	ldx.q r22, r21, r25
+-	stlo.q r22, -32, r0
+-	ldx.q r22, r6,  r0
+-	sthi.q r22, -17, r23
+-	sthi.q r22,  -9, r24
+-	sthi.q r22,  -1, r25
+-	stlo.q r22, -24, r23
+-	stlo.q r22, -16, r24
+-	stlo.q r22,  -8, r25
+-	bgeu r27, r22, tr0
++	shll8	r6		! 102 EX		! LMNx
++	mov	r1,r7		!   5 MT (latency=0)
+ 
+-Loop_ua:
+-	addi r22, 8, r22
+-	sthi.q r22, -1, r0
+-	stlo.q r22, -8, r0
+-	ldx.q r22, r6, r0
+-	bgtu/l r5, r22, tr1
++	or	r6,r3		!  82 EX		! LMNO
++	bt/s	3b		! 109 BR
+ 
+-	add r3, r4, r7
+-	ldlo.q r7, -8, r1
+-	sthi.q r22, 7, r0
+-	ldhi.q r7, -1, r7
+-	ptabs r18,tr1
+-	stlo.q r22, 0, r0
+-	or r1, r7, r1
+-	sthi.q r5, 15, r1
+-	stlo.q r5, 8, r1
+-	blink tr1, r63
++	 mov.l	r3,@-r0		!  30 LS
++#endif
++	! Finally, copy a byte at once, if necessary
+ 
+-#else /* ! SHMEDIA, i.e. SH1 .. SH4 / SHcompact */
++	add	#4,r5		!  50 EX
++	cmp/eq	r4,r0		!  54 MT
+ 
+-#ifdef __SH5__
+-#define DST r2
+-#define SRC r3
+-#define COUNT r4
+-#define TMP0 r5
+-#define TMP1 r6
+-#define RESULT r2
++	add	#-6,r2		!  50 EX
++	bt	9f		! 109 BR
++
++8:	cmp/hi	r2,r0		!  57 MT
++	mov.b	@(r0,r5),r1	!  20 LS (latency=2)
++
++	bt/s	8b		! 109 BR
++
++	 mov.b	r1,@-r0		!  29 LS
++
++9:	rts
++	 nop
++
++
++	!
++	!	GHIJ KLMN OPQR -->  .GHI JKLM NOPQ R...
++	!
++
++	! Size is 16 or greater, and may have trailing bytes
++
++	.balign	32
++.Lcase3:
++	! Read a long word and write a long word at once
++	! At the start of each iteration, r7 contains last long load
++	add	#-3,r5		! 79 EX
++	mov	r4,r2		!  5 MT (0 cycles latency)
++
++	mov.l	@(r0,r5),r7	! 21 LS (2 cycles latency)
++	add	#-4,r5		! 50 EX
++
++	add	#7,r2		!  79 EX
++	!
++#ifdef __LITTLE_ENDIAN__
++	! 6 cycles, 4 bytes per iteration
++3:	mov.l	@(r0,r5),r1	!  21 LS (latency=2)	! NMLK
++	mov	r7, r3		!   5 MT (latency=0)	! RQPO
++
++	cmp/hi	r2,r0		!  57 MT
++	shll8	r3		! 102 EX		! QPOx
++
++	mov	r1,r6		!   5 MT (latency=0)
++	shlr16	r6		! 107 EX
++
++	shlr8	r6		! 106 EX		! xxxN
++	mov	r1, r7		!   5 MT (latency=0)
++
++	or	r6,r3		!  82 EX		! QPON
++	bt/s	3b		! 109 BR
++
++	 mov.l	r3,@-r0		!  30 LS
+ #else
+-#define DST r4
+-#define SRC r5
+-#define COUNT r6
+-#define TMP0 r2
+-#define TMP1 r3
+-#define RESULT r0
++3:	mov	r7,r3		! OPQR
++	shlr8	r3		! xOPQ
++	mov.l	@(r0,r5),r7	! KLMN
++	mov	r7,r6
++	shll16	r6
++	shll8	r6		! Nxxx
++	or	r6,r3		! NOPQ
++	cmp/hi	r2,r0
++	bt/s	3b
++	 mov.l	r3,@-r0
+ #endif
+ 
++	! Finally, copy a byte at once, if necessary
++
++	add	#6,r5		!  50 EX
++	cmp/eq	r4,r0		!  54 MT
++
++	add	#-6,r2		!  50 EX
++	bt	9f		! 109 BR
++
++8:	cmp/hi	r2,r0		!  57 MT
++	mov.b	@(r0,r5),r1	!  20 LS (latency=2)
++
++	bt/s	8b		! 109 BR
++
++	 mov.b	r1,@-r0		!  29 LS
++
++9:	rts
++	 nop
++
++ENTRY(memcpy)
++
++	! Calculate the invariants which will be used in the remainder
++	! of the code:
++	!
++	!      r4   -->  [ ...  ] DST             [ ...  ] SRC
++	!	         [ ...  ]                 [ ...  ]
++	!	           :                        :
++	!      r0   -->  [ ...  ]       r0+r5 --> [ ...  ]
++	!
++	!
++
++	! Short circuit the common case of src, dst and len being 32 bit aligned
++	! and test for zero length move
++
++	mov	r6, r0		!   5 MT (0 cycle latency)
++	or	r4, r0		!  82 EX
++
++	or	r5, r0		!  82 EX
++	tst	r6, r6		!  86 MT
++
++	bt/s	99f		! 111 BR		(zero len)
++	 tst	#3, r0		!  87 MT
++
++	mov	r4, r0		!   5 MT (0 cycle latency)
++	add	r6, r0		!  49 EX
++
++	bt/s	.Lcase00	! 111 BR		(aligned)
++	 sub	r4, r5		!  75 EX
++
++	! Arguments are not nicely long word aligned or zero len.
++	! Check for small copies, and if so do a simple byte at a time copy.
++	!
++	! Deciding on an exact value of 'small' is not easy, as the point at which
++	! using the optimised routines become worthwhile varies (these are the
++	! cycle counts for differnet sizes using byte-at-a-time vs. optimised):
++	!	size	byte-at-time	long	word	byte
++	!	16	42		39-40	46-50	50-55
++	!	24	58		43-44	54-58	62-67
++	!	36	82		49-50	66-70	80-85
++	! However the penalty for getting it 'wrong' is much higher for long word
++	! aligned data (and this is more common), so use a value of 16.
++
++	mov	#16, r1		!   6 EX
++	cmp/gt	r6,r1		!  56 MT
++
++	add	#-1,r5		!  50 EX
++	bf/s	6f		! 108 BR		(not small)
++
++	 mov	r5, r3		!   5 MT (latency=0)
++	shlr	r6		! 104 EX
++
++	mov.b	@(r0,r5),r1	!  20 LS (latency=2)
++	bf/s	4f		! 111 BR
++
++	 add	#-1,r3		!  50 EX
++	tst	r6, r6		!  86 MT
++
++	bt/s	98f		! 110 BR
++	 mov.b	r1,@-r0		!  29 LS
++
++	! 4 cycles, 2 bytes per iteration
++3:	mov.b	@(r0,r5),r1	!  20 LS (latency=2)
++
++4:	mov.b	@(r0,r3),r2	!  20 LS (latency=2)
++	dt	r6		!  67 EX
++
++	mov.b	r1,@-r0		!  29 LS
++	bf/s	3b		! 111 BR
++
++	 mov.b	r2,@-r0		!  29 LS
++98:
++	rts
++	 nop
++
++99:	rts
++	 mov	r4, r0
++
++	! Size is not small, so its worthwhile looking for optimisations.
++	! First align destination to a long word boundary.
++	!
++	! r5 = normal value -1
++
++6:	tst	#3, r0		!  87 MT
++        mov	#3, r3		!   6 EX
++
++	bt/s	2f		! 111 BR
++	 and	r0,r3		!  78 EX
++
++	! 3 cycles, 1 byte per iteration
++1:	dt	r3		!  67 EX
++	mov.b	@(r0,r5),r1	!  19 LS (latency=2)
++
++	add	#-1, r6		!  79 EX
++	bf/s	1b		! 109 BR
++
++	 mov.b	r1,@-r0		!  28 LS
++
++2:	add	#1, r5		!  79 EX
++
++	! Now select the appropriate bulk transfer code based on relative
++	! alignment of src and dst.
++
++	mov	r0, r3		!   5 MT (latency=0)
++
++	mov	r5, r0		!   5 MT (latency=0)
++	tst	#1, r0		!  87 MT
++
++	bf/s	1f		! 111 BR
++	 mov	#64, r7		!   6 EX
++
++	! bit 0 clear
++
++	cmp/ge	r7, r6		!  55 MT
++
++	bt/s	2f		! 111 BR
++	 tst	#2, r0		!  87 MT
++
++	! small
++	bt/s	.Lcase0
++	 mov	r3, r0
++
++	bra	.Lcase2
++	 nop
++
++	! big
++2:	bt/s	.Lcase0b
++	 mov	r3, r0
++
++	bra	.Lcase2b
++	 nop
++
++	! bit 0 set
++1:	tst	#2, r0		! 87 MT
++
++	bt/s	.Lcase1
++	 mov	r3, r0
++
++	bra	.Lcase3
++	 nop
++
++
++	!
++	!	GHIJ KLMN OPQR -->  GHIJ KLMN OPQR
++	!
++
++	! src, dst and size are all long word aligned
++	! size is non-zero
++
++	.balign	32
++.Lcase00:
++	mov	#64, r1		!   6 EX
++	mov	r5, r3		!   5 MT (latency=0)
++
++	cmp/gt	r6, r1		!  56 MT
++	add	#-4, r5		!  50 EX
++
++	bf	.Lcase00b	! 108 BR		(big loop)
++	shlr2	r6		! 105 EX
++
++	shlr	r6		! 104 EX
++	mov.l	@(r0, r5), r1	!  21 LS (latency=2)
++
++	bf/s	4f		! 111 BR
++	 add	#-8, r3		!  50 EX
++
++	tst	r6, r6		!  86 MT
++	bt/s	5f		! 110 BR
++
++	 mov.l	r1,@-r0		!  30 LS
++
++	! 4 cycles, 2 long words per iteration
++3:	mov.l	@(r0, r5), r1	!  21 LS (latency=2)
++
++4:	mov.l	@(r0, r3), r2	!  21 LS (latency=2)
++	dt	r6		!  67 EX
++
++	mov.l	r1, @-r0	!  30 LS
++	bf/s	3b		! 109 BR
++
++	 mov.l	r2, @-r0	!  30 LS
++
++5:	rts
++	 nop
++
++
++	! Size is 16 or greater and less than 64, but may have trailing bytes
++
++	.balign	32
++.Lcase0:
++	add	#-4, r5		!  50 EX
++	mov	r4, r7		!   5 MT (latency=0)
++
++	mov.l	@(r0, r5), r1	!  21 LS (latency=2)
++	mov	#4, r2		!   6 EX
++
++	add	#11, r7		!  50 EX
++	tst	r2, r6		!  86 MT
++
++	mov	r5, r3		!   5 MT (latency=0)
++	bt/s	4f		! 111 BR
++
++	 add	#-4, r3		!  50 EX
++	mov.l	r1,@-r0		!  30 LS
++
++	! 4 cycles, 2 long words per iteration
++3:	mov.l	@(r0, r5), r1	!  21 LS (latency=2)
++
++4:	mov.l	@(r0, r3), r2	!  21 LS (latency=2)
++	cmp/hi	r7, r0
++
++	mov.l	r1, @-r0	!  30 LS
++	bt/s	3b		! 109 BR
++
++	 mov.l	r2, @-r0	!  30 LS
++
++	! Copy the final 0-3 bytes
++
++	add	#3,r5		!  50 EX
++
++	cmp/eq	r0, r4		!  54 MT
++	add	#-10, r7	!  50 EX
++
++	bt	9f		! 110 BR
++
++	! 3 cycles, 1 byte per iteration
++1:	mov.b	@(r0,r5),r1	!  19 LS
++	cmp/hi	r7,r0		!  57 MT
++
++	bt/s	1b		! 111 BR
++	 mov.b	r1,@-r0		!  28 LS
++
++9:	rts
++	 nop
++
++	! Size is at least 64 bytes, so will be going round the big loop at least once.
++	!
++	!   r2 = rounded up r4
++	!   r3 = rounded down r0
++
++	.balign	32
++.Lcase0b:
++	add	#-4, r5		!  50 EX
++
++.Lcase00b:
++	mov	r0, r3		!   5 MT (latency=0)
++	mov	#(~0x1f), r1	!   6 EX
++
++	and	r1, r3		!  78 EX
++	mov	r4, r2		!   5 MT (latency=0)
++
++	cmp/eq	r3, r0		!  54 MT
++	add	#0x1f, r2	!  50 EX
++
++	bt/s	1f		! 110 BR
++	 and	r1, r2		!  78 EX
++
++	! copy initial words until cache line aligned
++
++	mov.l	@(r0, r5), r1	!  21 LS (latency=2)
++	tst	#4, r0		!  87 MT
++
++	mov	r5, r6		!   5 MT (latency=0)
++	add	#-4, r6		!  50 EX
++
++	bt/s	4f		! 111 BR
++	 add	#8, r3		!  50 EX
++
++	tst	#0x18, r0	!  87 MT
++
++	bt/s	1f		! 109 BR
++	 mov.l	r1,@-r0		!  30 LS
++
++	! 4 cycles, 2 long words per iteration
++3:	mov.l	@(r0, r5), r1	!  21 LS (latency=2)
++
++4:	mov.l	@(r0, r6), r7	!  21 LS (latency=2)
++	cmp/eq	r3, r0		!  54 MT
++
++	mov.l	r1, @-r0	!  30 LS
++	bf/s	3b		! 109 BR
++
++	 mov.l	r7, @-r0	!  30 LS
++
++#ifdef MEMCPY_USES_FPU
++	! Copy the cache line aligned blocks by using the FPU registers.
++	! If src and dst are well aligned adopt 64-bit data transfer.
++	! We also need r0 as a temporary (for movca), so 'undo' the invariant:
++	!   r5:	 src (was r0+r5)
++	!   r1:	 dest (was r0)
++1:
++	add	r0, r5
++	mov	r0, r1
++
++	mov	r1, r3		! MT
++	sub	r2, r3		! EX (r3 - r2 -> r3)
++	mov	#-5, r0
++	shld	r0, r3		! number of the cache lines
++
++	mov	#8, r0
++	cmp/ge	r0, r3		! Check if there are many cache lines to copy.
++	bf	45f		! Copy cache line aligned blocks without pref.
++	mov	r5, r0
++	add	#-0x7c, r0
++	tst	#7, r0		! src is 8byte aligned
++	bf	45f
++
++	! Many cache lines have to be copied and the buffers are well aligned.
++	! Aggressive prefetching and FPU in single paired precision.
++	mov	r0, r5
++	mov	r5, r6
++	add	#-0x80, r6	! prefetch head
++
++	! store FPU (in single precision mode, do not check R15 align).
++	fmov	fr12, @-r15
++	fmov	fr13, @-r15
++	fmov	fr14, @-r15
++	fmov	fr15, @-r15
++
++	FPU_SET_PAIRED_PREC
++
++	mov	#4, r0
++67:
++	add	#-0x20, r6
++	pref	@r6
++	add	#-0x20, r6
++	pref	@r6
++
++	fmov	@r5+, dr0
++	fmov	@r5+, dr2
++	fmov	@r5+, dr4
++	fmov	@r5+, dr6
++	fmov	@r5+, dr8
++	fmov	@r5+, dr10
++	fmov	@r5+, dr12
++	fmov	@r5+, dr14
++	fmov	@r5+, xd0
++	fmov	@r5+, xd2
++	fmov	@r5+, xd4
++	fmov	@r5+, xd6
++	fmov	@r5+, xd8
++	fmov	@r5+, xd10
++	fmov	@r5+, xd12
++	fmov	@r5+, xd14
++
++	DALLOC
++	fmov	xd14, @-r1
++	fmov	xd12, @-r1
++	fmov	xd10, @-r1
++	fmov	xd8, @-r1
++	DALLOC
++	fmov	xd6, @-r1
++	fmov	xd4, @-r1
++	fmov	xd2, @-r1
++	fmov	xd0, @-r1
++	DALLOC
++	fmov	dr14, @-r1
++	fmov	dr12, @-r1
++	fmov	dr10, @-r1
++	fmov	dr8, @-r1
++	DALLOC
++	fmov	dr6, @-r1
++	add	#-0x80, r5
++	fmov	dr4, @-r1
++	add	#-0x80, r5
++	fmov	dr2, @-r1
++	add	#-0x20, r6
++	fmov	dr0, @-r1
++	add	#-4, r3
++	pref	@r6
++	add	#-0x20, r6
++	cmp/ge	r0, r3
++	bt/s	67b
++	 pref	@r6
++
++	RESTORE_FPSCR
++
++	! Restore FPU callee save registers
++	fmov	@r15+, fr15
++	fmov	@r15+, fr14
++	fmov	@r15+, fr13
++	fmov	@r15+, fr12
++
++	! Other cache lines could be copied: so use the FPU in single paired
++	! precision without prefetching. No check for alignment is necessary.
++
++	mov	#1, r0
++	cmp/ge	r0, r3
++	bt/s	3f
++	 add	#0x60, r5
++
++	bra	5f
++	 nop
++
++	! No prefetch and FPU in single precision.
++45:
++	add	#-0x1c, r5
++	mov	r5, r0
++	tst	#7, r0
++	bt	3f
++
++2:	fmov.s	@r5+, fr0
++	fmov.s	@r5+, fr1
++	fmov.s	@r5+, fr2
++	fmov.s	@r5+, fr3
++	fmov.s	@r5+, fr4
++	fmov.s	@r5+, fr5
++	fmov.s	@r5+, fr6
++	fmov.s	@r5+, fr7
++
++	DALLOC
++
++	fmov.s	fr7, @-r1
++	fmov.s	fr6, @-r1
++	fmov.s	fr5, @-r1
++	fmov.s	fr4, @-r1
++	fmov.s	fr3, @-r1
++	fmov.s	fr2, @-r1
++	fmov.s	fr1, @-r1
++	fmov.s	fr0, @-r1
++
++	cmp/eq	r2,r1
++
++	bf/s	2b
++	 add	#-0x40, r5
++
++	bra	5f
++	 nop
++
++	! No prefetch and FPU in single paired precision.
++
++3:	FPU_SET_PAIRED_PREC
++
++4:	fmov	@r5+, dr0
++	fmov	@r5+, dr2
++	fmov	@r5+, dr4
++	fmov	@r5+, dr6
++
++	DALLOC
++
++	fmov	dr6, @-r1
++	fmov	dr4, @-r1
++	fmov	dr2, @-r1
++	fmov	dr0, @-r1
++	cmp/eq	r2,r1
++
++	bf/s	4b
++	 add	#-0x40, r5
++
++	RESTORE_FPSCR
++
++5:	mov	r1, r0
++
++	cmp/eq	r4, r0		!  54 MT
++	bf/s	1f		! 109 BR
++	 sub	r1, r5		!  75 EX
++
++	rts
++	 nop
++1:
++#else
++	! Copy the cache line aligned blocks
++	!
++	! In use: r0, r2, r4, r5
++	! Scratch: r1, r3, r6, r7
++	!
++	! We could do this with the four scratch registers, but if src
++	! and dest hit the same cache line, this will thrash, so make
++	! use of additional registers.
++	!
++	! We also need r0 as a temporary (for movca), so 'undo' the invariant:
++	!   r5:	 src (was r0+r5)
++	!   r1:	 dest (was r0)
++	! this can be reversed at the end, so we don't need to save any extra
++	! state.
++	!
++1:	mov.l	r8, @-r15	!  30 LS
++	add	r0, r5		!  49 EX
++
++	mov.l	r9, @-r15	!  30 LS
++	mov	r0, r1		!   5 MT (latency=0)
++
++	mov.l	r10, @-r15	!  30 LS
++	add	#-0x1c, r5	!  50 EX
++
++	mov.l	r11, @-r15	!  30 LS
++
++	! 16 cycles, 32 bytes per iteration
++2:	mov.l	@(0x00,r5),r0	! 18 LS (latency=2)
++	add	#-0x20, r1	! 50 EX
++	mov.l	@(0x04,r5),r3	! 18 LS (latency=2)
++	mov.l	@(0x08,r5),r6	! 18 LS (latency=2)
++	mov.l	@(0x0c,r5),r7	! 18 LS (latency=2)
++	mov.l	@(0x10,r5),r8	! 18 LS (latency=2)
++	mov.l	@(0x14,r5),r9	! 18 LS (latency=2)
++	mov.l	@(0x18,r5),r10	! 18 LS (latency=2)
++	mov.l	@(0x1c,r5),r11	! 18 LS (latency=2)
++	movca.l	r0,@r1		! 40 LS (latency=3-7)
++	mov.l	r3,@(0x04,r1)	! 33 LS
++	mov.l	r6,@(0x08,r1)	! 33 LS
++	mov.l	r7,@(0x0c,r1)	! 33 LS
++
++	mov.l	r8,@(0x10,r1)	! 33 LS
++	add	#-0x20, r5	! 50 EX
++
++	mov.l	r9,@(0x14,r1)	! 33 LS
++	cmp/eq	r2,r1		! 54 MT
++
++	mov.l	r10,@(0x18,r1)	!  33 LS
++	bf/s	2b		! 109 BR
++
++	 mov.l	r11,@(0x1c,r1)	!  33 LS
++
++	mov	r1, r0		!   5 MT (latency=0)
++
++	mov.l	@r15+, r11	!  15 LS
++	sub	r1, r5		!  75 EX
++
++	mov.l	@r15+, r10	!  15 LS
++	cmp/eq	r4, r0		!  54 MT
++
++	bf/s	1f		! 109 BR
++	 mov.l	 @r15+, r9	!  15 LS
++
++	rts
++1:	 mov.l	@r15+, r8	!  15 LS
++#endif
++	sub	r4, r1		!  75 EX		(len remaining)
++
++	! number of trailing bytes is non-zero
++	!
++	! invariants restored (r5 already decremented by 4)
++	! also r1=num bytes remaining
++
++	mov	#4, r2		!   6 EX
++	mov	r4, r7		!   5 MT (latency=0)
++
++	add	#0x1c, r5	!  50 EX		(back to -4)
++	cmp/hs	r2, r1		!  58 MT
++
++	bf/s	5f		! 108 BR
++	 add	 #11, r7	!  50 EX
++
++	mov.l	@(r0, r5), r6	!  21 LS (latency=2)
++	tst	r2, r1		!  86 MT
++
++	mov	r5, r3		!   5 MT (latency=0)
++	bt/s	4f		! 111 BR
++
++	 add	#-4, r3		!  50 EX
++	cmp/hs	r2, r1		!  58 MT
++
++	bt/s	5f		! 111 BR
++	 mov.l	r6,@-r0		!  30 LS
++
++	! 4 cycles, 2 long words per iteration
++3:	mov.l	@(r0, r5), r6	!  21 LS (latency=2)
++
++4:	mov.l	@(r0, r3), r2	!  21 LS (latency=2)
++	cmp/hi	r7, r0
++
++	mov.l	r6, @-r0	!  30 LS
++	bt/s	3b		! 109 BR
++
++	 mov.l	r2, @-r0	!  30 LS
++
++	! Copy the final 0-3 bytes
++
++5:	cmp/eq	r0, r4		!  54 MT
++	add	#-10, r7	!  50 EX
++
++	bt	9f		! 110 BR
++	add	#3,r5		!  50 EX
++
++	! 3 cycles, 1 byte per iteration
++1:	mov.b	@(r0,r5),r1	!  19 LS
++	cmp/hi	r7,r0		!  57 MT
++
++	bt/s	1b		! 111 BR
++	 mov.b	r1,@-r0		!  28 LS
++
++9:	rts
++	 nop
++
++	!
++	!	GHIJ KLMN OPQR -->  ..GH IJKL MNOP QR..
++	!
++
++	.balign	32
++.Lcase2:
++	! Size is 16 or greater and less then 64, but may have trailing bytes
++
++2:	mov	r5, r6		!   5 MT (latency=0)
++	add	#-2,r5		!  50 EX
++
++	mov	r4,r2		!   5 MT (latency=0)
++	add	#-4,r6		!  50 EX
++
++	add	#7,r2		!  50 EX
++3:	mov.w	@(r0,r5),r1	!  20 LS (latency=2)
++
++	mov.w	@(r0,r6),r3	!  20 LS (latency=2)
++	cmp/hi	r2,r0		!  57 MT
++
++	mov.w	r1,@-r0		!  29 LS
++	bt/s	3b		! 111 BR
++
++	 mov.w	r3,@-r0		!  29 LS
++
++	bra	10f
++	 nop
++
++
++	.balign	32
++.Lcase2b:
++	! Size is at least 64 bytes, so will be going round the big loop at least once.
++	!
++	!   r2 = rounded up r4
++	!   r3 = rounded down r0
++
++	mov	r0, r3		!   5 MT (latency=0)
++	mov	#(~0x1f), r1	!   6 EX
++
++	and	r1, r3		!  78 EX
++	mov	r4, r2		!   5 MT (latency=0)
++
++	cmp/eq	r3, r0		!  54 MT
++	add	#0x1f, r2	!  50 EX
++
++	add	#-2, r5		!  50 EX
++	bt/s	1f		! 110 BR
++	 and	r1, r2		!  78 EX
++
++	! Copy a short word one at a time until we are cache line aligned
++	!   Normal values: r0, r2, r3, r4
++	!   Unused: r1, r6, r7
++	!   Mod: r5 (=r5-2)
++	!
++	add	#2, r3		!  50 EX
++
++2:	mov.w	@(r0,r5),r1	!  20 LS (latency=2)
++	cmp/eq	r3,r0		!  54 MT
++
++	bf/s	2b		! 111 BR
++
++	 mov.w	r1,@-r0		!  29 LS
++
++	! Copy the cache line aligned blocks
++	!
++	! In use: r0, r2, r4, r5 (=r5-2)
++	! Scratch: r1, r3, r6, r7
++	!
++	! We could do this with the four scratch registers, but if src
++	! and dest hit the same cache line, this will thrash, so make
++	! use of additional registers.
++	!
++	! We also need r0 as a temporary (for movca), so 'undo' the invariant:
++	!   r5:	 src (was r0+r5)
++	!   r1:	 dest (was r0)
++	! this can be reversed at the end, so we don't need to save any extra
++	! state.
++	!
++1:	mov.l	r8, @-r15	!  30 LS
++	add	r0, r5		!  49 EX
++
++	mov.l	r9, @-r15	!  30 LS
++	mov	r0, r1		!   5 MT (latency=0)
++
++	mov.l	r10, @-r15	!  30 LS
++	add	#-0x1e, r5	!  50 EX
++
++	mov.l	r11, @-r15	!  30 LS
++
++	mov.l	r12, @-r15	!  30 LS
++
++	! 17 cycles, 32 bytes per iteration
+ #ifdef __LITTLE_ENDIAN__
+-	! Little endian version copies with increasing addresses.
+-	mov DST,TMP1	! Save return value
+-	mov #11,r0	! Check if small number of bytes
+-	cmp/hs r0,COUNT
+-			! COUNT becomes src end address
+-	SL(bf, L_small, add SRC,COUNT)
+-	mov #1,r1
+-	tst r1,SRC	! check if source even
+-	SL(bt, L_even, mov COUNT,r7)
+-	mov.b @SRC+,r0	! no, make it even.
+-	mov.b r0,@DST
+-	add #1,DST
+-L_even:	tst r1,DST	! check if destination is even
+-	add #-3,r7
+-	SL(bf, L_odddst, mov #2,r1)
+-	tst r1,DST	! check if destination is 4-byte aligned
+-	mov DST,r0
+-	SL(bt, L_al4dst, sub SRC,r0)
+-	mov.w @SRC+,TMP0
+-	mov.w TMP0,@DST
+-	! add #2,DST  DST is dead here.
+-L_al4dst:
+-	tst r1,SRC
+-	bt L_al4both
+-	mov.w @SRC+,r1
+-	swap.w r1,r1
+-	add #-6,r0
+-	add #-6,r7	! r7 := src end address minus 9.
+-	.align 2
+-L_2l_loop:
+-	mov.l @SRC+,TMP0 ! Read & write two longwords per iteration
+-	xtrct TMP0,r1
+-	mov.l r1,@(r0,SRC)
+-	cmp/hs r7,SRC
+-	mov.l @SRC+,r1
+-	xtrct r1,TMP0
+-	mov.l TMP0,@(r0,SRC)
+-	bf L_2l_loop
+-	add #-2,SRC
+-	bra  L_cleanup
+-	add #5,r0
+-L_al4both:
+-	add #-4,r0
+-	.align 2
+-L_al4both_loop:
+-	mov.l @SRC+,DST   ! Read longword, write longword per iteration
+-	cmp/hs r7,SRC
+-	SL(bf, L_al4both_loop, mov.l DST,@(r0,SRC))
++2:	mov.w	@r5+, r0	!  14 LS (latency=2)		..JI
++	add	#-0x20, r1	!  50 EX
+ 
+-	bra L_cleanup
+-	add #3,r0
++	mov.l	@r5+, r3	!  15 LS (latency=2)		NMLK
+ 
+-L_odddst:
+-	tst r1,SRC
+-	SL(bt, L_al4src, add #-1,DST)
+-	mov.w @SRC+,r0
+-	mov.b r0,@(1,DST)
+-	shlr8 r0
+-	mov.b r0,@(2,DST)
+-	add #2,DST
+-L_al4src:
+-	.align 2
+-L_odd_loop:
+-	mov.l @SRC+,r0   ! Read longword, write byte, word, byte per iteration
+-	cmp/hs r7,SRC
+-	mov.b r0,@(1,DST)
+-	shlr8 r0
+-	mov.w r0,@(2,DST)
+-	shlr16 r0
+-	mov.b r0,@(4,DST)
+-	SL(bf, L_odd_loop, add #4,DST)
+-	.align 2 ! avoid nop in more frequently executed code.
+-L_cleanup2:
+-	mov	DST,r0
+-	sub	SRC,r0
+-L_cleanup:
+-	cmp/eq	COUNT,SRC
+-	bt	L_ready
+-	.align 2
+-L_cleanup_loop:
+-	mov.b	@SRC+,r1
+-	cmp/eq	COUNT,SRC
+-	mov.b	r1,@(r0,SRC)
+-	bf	L_cleanup_loop
+-L_ready:
++	mov.l	@r5+, r6	!  15 LS (latency=2)		RQPO
++	shll16	r0		! 103 EX			JI..
++
++	mov.l	@r5+, r7	!  15 LS (latency=2)
++	xtrct	r3, r0		!  48 EX			LKJI
++
++	mov.l	@r5+, r8	!  15 LS (latency=2)
++	xtrct	r6, r3		!  48 EX			PONM
++
++	mov.l	@r5+, r9	!  15 LS (latency=2)
++	xtrct	r7, r6		!  48 EX
++
++	mov.l	@r5+, r10	!  15 LS (latency=2)
++	xtrct	r8, r7		!  48 EX
++
++	mov.l	@r5+, r11	!  15 LS (latency=2)
++	xtrct	r9, r8		!  48 EX
++
++	mov.w	@r5+, r12	!  15 LS (latency=2)
++	xtrct	r10, r9		!  48 EX
++
++	movca.l	r0,@r1		!  40 LS (latency=3-7)
++	xtrct	r11, r10	!  48 EX
++
++	mov.l	r3, @(0x04,r1)	!  33 LS
++	xtrct	r12, r11	!  48 EX
++
++	mov.l	r6, @(0x08,r1)	!  33 LS
++
++	mov.l	r7, @(0x0c,r1)	!  33 LS
++
++	mov.l	r8, @(0x10,r1)	!  33 LS
++	add	#-0x40, r5	!  50 EX
++
++	mov.l	r9, @(0x14,r1)	!  33 LS
++	cmp/eq	r2,r1		!  54 MT
++
++	mov.l	r10, @(0x18,r1)	!  33 LS
++	bf/s	2b		! 109 BR
++
++	 mov.l	r11, @(0x1c,r1)	!  33 LS
++#else
++2:	mov.w	@(0x1e,r5), r0	!  17 LS (latency=2)
++	add	#-2, r5		!  50 EX
++
++	mov.l	@(0x1c,r5), r3	!  18 LS (latency=2)
++	add	#-4, r1		!  50 EX
++
++	mov.l	@(0x18,r5), r6	!  18 LS (latency=2)
++	shll16	r0		! 103 EX
++
++	mov.l	@(0x14,r5), r7	!  18 LS (latency=2)
++	xtrct	r3, r0		!  48 EX
++
++	mov.l	@(0x10,r5), r8	!  18 LS (latency=2)
++	xtrct	r6, r3		!  48 EX
++
++	mov.l	@(0x0c,r5), r9	!  18 LS (latency=2)
++	xtrct	r7, r6		!  48 EX
++
++	mov.l	@(0x08,r5), r10	!  18 LS (latency=2)
++	xtrct	r8, r7		!  48 EX
++
++	mov.l	@(0x04,r5), r11	!  18 LS (latency=2)
++	xtrct	r9, r8		!  48 EX
++
++	mov.l   @(0x00,r5), r12 !  18 LS (latency=2)
++	xtrct	r10, r9		!  48 EX
++
++	movca.l	r0,@r1		!  40 LS (latency=3-7)
++	add	#-0x1c, r1	!  50 EX
++
++	mov.l	r3, @(0x18,r1)	!  33 LS
++	xtrct	r11, r10	!  48 EX
++
++	mov.l	r6, @(0x14,r1)	!  33 LS
++	xtrct	r12, r11	!  48 EX
++
++	mov.l	r7, @(0x10,r1)	!  33 LS
++
++	mov.l	r8, @(0x0c,r1)	!  33 LS
++	add	#-0x1e, r5	!  50 EX
++
++	mov.l	r9, @(0x08,r1)	!  33 LS
++	cmp/eq	r2,r1		!  54 MT
++
++	mov.l	r10, @(0x04,r1)	!  33 LS
++	bf/s	2b		! 109 BR
++
++	 mov.l	r11, @(0x00,r1)	!  33 LS
++#endif
++
++	mov.l	@r15+, r12
++	mov	r1, r0		!   5 MT (latency=0)
++
++	mov.l	@r15+, r11	!  15 LS
++	sub	r1, r5		!  75 EX
++
++	mov.l	@r15+, r10	!  15 LS
++	cmp/eq	r4, r0		!  54 MT
++
++	bf/s	1f		! 109 BR
++	 mov.l	 @r15+, r9	!  15 LS
++
+ 	rts
+-	mov	TMP1,RESULT
+-L_small:
+-	bra L_cleanup2
+-	add #-1,DST
+-#else /* ! __LITTLE_ENDIAN__ */
+-	! Big endian version copies with decreasing addresses.
+-	mov DST,r0
+-	add COUNT,r0
+-	sub DST,SRC
+-	mov #11,r1
+-	cmp/hs r1,COUNT
+-	SL(bf, L_small, add #-1,SRC)
+-	mov SRC,TMP1
+-	add r0,TMP1
+-	shlr TMP1
+-	SL(bt, L_even,
+-	mov DST,r7)
+-	mov.b @(r0,SRC),TMP0
+-	add #-1,TMP1
+-	mov.b TMP0,@-r0
+-L_even:
+-	tst #1,r0
+-	add #-1,SRC
+-	SL(bf, L_odddst, add #8,r7)
+-	tst #2,r0
+-	bt L_al4dst
+-	add #-1,TMP1
+-	mov.w @(r0,SRC),r1
+-	mov.w r1,@-r0
+-L_al4dst:
+-	shlr TMP1
+-	bt L_al4both
+-	mov.w @(r0,SRC),r1
+-	swap.w r1,r1
+-	add #4,r7
+-	add #-4,SRC
+-	.align 2
+-L_2l_loop:
+-	mov.l @(r0,SRC),TMP0
+-	xtrct TMP0,r1
+-	mov.l r1,@-r0
+-	cmp/hs r7,r0
+-	mov.l @(r0,SRC),r1
+-	xtrct r1,TMP0
+-	mov.l TMP0,@-r0
+-	bt L_2l_loop
+-	bra L_cleanup
+-	add #5,SRC
++1:	 mov.l	@r15+, r8	!  15 LS
+ 
+-	nop ! avoid nop in executed code.
+-L_al4both:
+-	add #-2,SRC
+-	.align 2
+-L_al4both_loop:
+-	mov.l @(r0,SRC),r1
+-	cmp/hs r7,r0
+-	SL(bt, L_al4both_loop,
+-	mov.l r1,@-r0)
+-	bra L_cleanup
+-	add #3,SRC
++	add	#0x1e, r5	!  50 EX
+ 
+-	nop ! avoid nop in executed code.
+-L_odddst:
+-	shlr TMP1
+-	bt L_al4src
+-	mov.w @(r0,SRC),r1
+-	mov.b r1,@-r0
+-	shlr8 r1
+-	mov.b r1,@-r0
+-L_al4src:
+-	add #-2,SRC
+-	.align 2
+-L_odd_loop:
+-	mov.l @(r0,SRC),TMP0
+-	cmp/hs r7,r0
+-	mov.b TMP0,@-r0
+-	shlr8 TMP0
+-	mov.w TMP0,@-r0
+-	shlr16 TMP0
+-	mov.b TMP0,@-r0
+-	bt L_odd_loop
++	! Finish off a short word at a time
++	! r5 must be invariant - 2
++10:	mov	r4,r2		!   5 MT (latency=0)
++	add	#1,r2		!  50 EX
+ 
+-	add #3,SRC
+-L_cleanup:
+-L_small:
+-	cmp/eq DST,r0
+-	bt L_ready
+-	add #1,DST
+-	.align 2
+-L_cleanup_loop:
+-	mov.b @(r0,SRC),TMP0
+-	cmp/eq DST,r0
+-	mov.b TMP0,@-r0
+-	bf L_cleanup_loop
+-L_ready:
++	cmp/hi	r2, r0		!  57 MT
++	bf/s	1f		! 109 BR
++
++	 add	#2, r2		!  50 EX
++
++3:	mov.w	@(r0,r5),r1	!  20 LS
++	cmp/hi	r2,r0		!  57 MT
++
++	bt/s	3b		! 109 BR
++
++	 mov.w	r1,@-r0		!  29 LS
++1:
++
++	!
++	! Finally, copy the last byte if necessary
++	cmp/eq	r4,r0		!  54 MT
++	bt/s	9b
++	 add	#1,r5
++	mov.b	@(r0,r5),r1
+ 	rts
+-	mov r0,RESULT
+-#endif /* ! __LITTLE_ENDIAN__ */
+-#endif /* ! SHMEDIA */
++	 mov.b	r1,@-r0
+diff --color -ruN newlib-4.5.0.20241231/newlib/libc/machine/sh/memset.S newlib-4.5.0.20241231-kos/newlib/libc/machine/sh/memset.S
+--- newlib-4.5.0.20241231/newlib/libc/machine/sh/memset.S	2023-01-21 04:01:54
++++ newlib-4.5.0.20241231-kos/newlib/libc/machine/sh/memset.S	2023-04-21 19:00:00
+@@ -1,164 +1,150 @@
+-!
+-! Fast SH memset
+-!
+-! by Toshiyasu Morita (tm@netcom.com)
+-!
+-! SH5 code by J"orn Rennecke (joern.rennecke@superh.com)
+-! Copyright 2002 SuperH Ltd.
+-!
++/* $Id: memset.S,v 1.1 2000/04/14 16:49:01 mjd Exp $
++ *
++ * "memset" implementation of SuperH
++ *
++ * Copyright (C) 1999  Niibe Yutaka
++ *
++ * Copyright (c) 2009  STMicroelectronics Ltd
++ *   Optimised using 64bit data transfer (via FPU) and the movca.l inst.
++ *   Author: Giuseppe Cavallaro <peppe.cavallaro@st.com>
++ *
++ * Licensed under the LGPL v2.1, see the file COPYING.LIB in this tarball.
++ */
+ 
++/*
++ *            void *memset(void *s, int c, size_t n);
++ */
++
+ #include "asm.h"
+ 
+-ENTRY(memset)
+-#if __SHMEDIA__
+-	pta/l multiquad, tr0
+-	ptabs r18, tr2
++#if defined (__LITTLE_ENDIAN__) && defined (__SH_FPU_ANY__)
++#define MEMSET_USES_FPU
++/* Use paired single precision load or store mode for 64-bit tranfering.
++ * FPSCR.SZ=1,FPSCR.SZ=0 is well defined on both SH4-200 and SH4-300.
++ * Currenlty it has been only implemented and tested for little endian mode. */
++.macro FPU_SET_PAIRED_PREC
++	sts	fpscr, r3
++	mov	#0x10, r1	! PR=0 SZ=1
++	shll16  r1
++	lds	r1, fpscr
++.endm
++.macro RESTORE_FPSCR
++	lds	r3, fpscr
++.endm
++#endif
+ 
+-	andi r2, -8, r25
+-	add r2, r4, r5
+-	addi r5, -1, r20    // calculate end address.
+-	andi r20, -8, r20
+-	cmveq r4, r25, r20
+-	bne/u r25, r20, tr0 // multiquad
++ENTRY(memset)
++	mov	#12,r0
++	add	r6,r4
++	cmp/gt	r6,r0
++	bt/s	40f		! if it's too small, set a byte at once
++	 mov	r4,r0
++	and	#3,r0
++	cmp/eq	#0,r0
++	bt/s	2f		! It's aligned
++	 sub	r0,r6
++1:
++	dt	r0
++	bf/s	1b
++	 mov.b	r5,@-r4
++2:				! make VVVV
++	extu.b	r5,r5
++	swap.b	r5,r0		!   V0
++	or	r0,r5		!   VV
++	swap.w	r5,r0		! VV00
++	or	r0,r5		! VVVV
+ 
+-!	This sequence could clobber volatile objects that are in the same
+-!	quadword as a very short char array.
+-!	ldlo.q r2, 0, r7
+-!	shlli r4, 2, r4
+-!	movi -1, r8
+-!	SHHI r8, r4, r8
+-!	SHHI r8, r4, r8
+-!	mcmv r7, r8, r3
+-!	stlo.q r2, 0, r3
++	! Check if enough bytes need to be copied to be worth the big loop
++	mov	#0x40, r0	! (MT)
++	cmp/gt	r6,r0		! (MT)  64 > len => slow loop
+ 
+-	pta/l setlongs, tr0
+-	movi 4, r8
+-	bgeu/u r4, r8, tr0
+-	pta/l endset, tr0
+-	beqi/u r4, 0, tr0
+-	st.b r2, 0, r3
+-	beqi/u r4, 1, tr0
+-	nop
+-	st.b r2, 1, r3
+-	beqi/l r4, 2, tr0
+-	st.b r2,2,r3
+-endset: blink tr2, r63
+-setlongs:
+-	mshflo.b r3, r3, r3
+-	mperm.w r3, r63, r3	// Fill pattern now in every byte of r3
+-	stlo.l r2, 0, r3
+-	nop
+-	nop
+-	sthi.l r5, -1, r3
+-	blink tr2, r63
++	bt/s	22f
++	 mov	r6,r0
+ 
+-multiquad:
+-	mshflo.b r3, r3, r3
+-	mperm.w r3, r63, r3	// Fill pattern now in every byte of r3
+-	pta/l lastquad, tr0
+-	stlo.q r2, 0, r3
+-	sub r20, r25, r24
+-	movi 64, r9
+-	beqi/u r24, 8, tr0 // lastquad
+-	pta/l loop, tr1
+-	addi r20, -7*8, r8 // loop end address; This might overflow, so we need
+-	                   // to use a different test before we start the loop
+-	bgeu/u r24, r9, tr1// loop
+-	st.q r25, 8, r3
+-	shlri r24, 4, r24
+-	st.q r20, -8, r3
+-	beqi/u r24, 1, tr0 // lastquad
+-	st.q r25, 16, r3
+-	st.q r20, -16, r3
+-	beqi/u r24, 2, tr0 // lastquad
+-	st.q r25, 24, r3
+-	st.q r20, -24, r3
+-lastquad:
+-	sthi.q r5, -1, r3
+-	blink tr2,r63
++	! align the dst to the cache block size if necessary
++	mov	r4, r3
++	mov	#~(0x1f), r1
+ 
+-loop:
+-	alloco r25, 32
+-	st.q r25, 8, r3
+-	st.q r25, 16, r3
+-	st.q r25, 24, r3
+-	st.q r25, 32, r3
+-	addi r25, 32, r25
+-	bgeu/l r8, r25, tr1 // loop
++	and	r3, r1
++	cmp/eq	r3, r1
+ 
+-	st.q r20, -40, r3
+-	st.q r20, -32, r3
+-	st.q r20, -24, r3
+-	st.q r20, -16, r3
+-	st.q r20, -8, r3
+-	sthi.q r5, -1, r3
+-	blink tr2,r63
+-#else /* ! SHMEDIA, i.e. SH1 .. SH4 / SHcompact */
+-! Entry: r4: destination pointer
+-!        r5: fill value
+-!        r6: byte count
+-!
+-! Exit:  r0-r3: trashed
+-!
++	bt/s	11f		! dst is already aligned
++	 sub	r1, r3		! r3-r1 -> r3
++	shlr2	r3		! number of loops
+ 
+-! This assumes that the first four bytes of the address space (0..3) are
+-! reserved - usually by the linker script.  Otherwise, we would had to check
+-! for the case of objects of the size 12..15 at address 0..3 .
++10:	mov.l	r5,@-r4
++	dt	r3
++	bf/s	10b
++	 add	#-4, r6
+ 
+-#ifdef __SH5__
+-#define DST r2
+-#define VAL r3
+-#define CNT r4
+-#define TMP r5
+-#else
+-#define DST r4
+-#define VAL r5
+-#define CNT r6
+-#define TMP r2
+-#endif
++11:	! dst is 32byte aligned
++	mov	r6,r2
++	mov	#-5,r0
++	shld	r0,r2		! number of loops
+ 
+-	mov	#12,r0	! Check for small number of bytes
+-	cmp/gt	CNT,r0
+-	mov	DST,r0
+-	SL(bt, L_store_byte_loop_check0, add DST,CNT)
++	add	#-32, r4
++	mov	r5, r0
+ 
+-	tst	#3,r0	! Align destination
+-	SL(bt,	L_dup_bytes, extu.b r5,r5)
+-	.balignw 4,0x0009
+-L_align_loop:
+-	mov.b	VAL,@r0
+-	add	#1,r0
+-	tst	#3,r0
+-	bf	L_align_loop
++#ifdef MEMSET_USES_FPU
++	lds	r5, fpul	! (CO)
++	fsts	fpul, fr0	! Dr0 will be 'VVVVVVVV'
++	fsts	fpul, fr1
+ 
+-L_dup_bytes:	
+-	swap.b	VAL,TMP	! Duplicate bytes across longword
+-	or	TMP,VAL
+-	swap.w	VAL,TMP
+-	or	TMP,VAL
++	FPU_SET_PAIRED_PREC
++12:
++	movca.l	r0, @r4
++	mov.l	r5, @(4, r4)
++	add	#32, r4
++	fmov	dr0, @-r4
++	fmov	dr0, @-r4
++	add	#-0x20, r6
++	fmov	dr0, @-r4
++	dt	r2
++	bf/s	12b
++	 add	#-40, r4
+ 
+-	add	#-16,CNT
++	RESTORE_FPSCR
++#else
++12:
++	movca.l	r0,@r4
++	mov.l	r5,@(4, r4)
++	mov.l	r5,@(8, r4)
++	mov.l	r5,@(12,r4)
++	mov.l	r5,@(16,r4)
++	mov.l	r5,@(20,r4)
++	add	#-0x20, r6
++	mov.l	r5,@(24,r4)
++	dt	r2
++	mov.l	r5,@(28,r4)
++	bf/s	12b
++	 add	#-32, r4
+ 
+-	.balignw 4,0x0009
+-L_store_long_loop:
+-	mov.l	VAL,@r0	! Store double longs to memory
+-	cmp/hs	CNT,r0
+-	mov.l	VAL,@(4,r0)
+-	SL(bf, L_store_long_loop, add #8,r0)
++#endif
++	add	#32, r4
++	mov	#8, r0
++	cmp/ge	r0, r6
++	bf	40f
+ 
+-	add	#16,CNT
++	mov	r6,r0
++22:
++	shlr2	r0
++	shlr	r0		! r0 = r6 >> 3
++3:
++	dt	r0
++	mov.l	r5,@-r4		! set 8-byte at once
++	bf/s	3b
++	 mov.l	r5,@-r4
++	!
++	mov	#7,r0
++	and	r0,r6
+ 
+-L_store_byte_loop_check0:
+-	cmp/eq	CNT,r0
+-	bt	L_exit
+-	.balignw 4,0x0009
+-L_store_byte_loop:
+-	mov.b	VAL,@r0	! Store bytes to memory
+-	add	#1,r0
+-	cmp/eq	CNT,r0
+-	bf	L_store_byte_loop
+-
+-L_exit:
++	! fill bytes (length may be zero)
++40:	tst	r6,r6
++	bt	5f
++4:
++	dt	r6
++	bf/s	4b
++	 mov.b	r5,@-r4
++5:
+ 	rts
+-	mov	r4,r0
+-#endif /* ! SHMEDIA */
++	 mov	r4,r0
+


### PR DESCRIPTION
I updated all of the KOS toolchains newer than `stable` to Newlib 4.5.0, so DreamShell should also have a Newlib 4.5.0 fastmem patch, just like with PR #25.